### PR TITLE
Add regulated asset support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stellar-demo-wallet",
-  "version": "0.0.44",
+  "version": "0.0.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4455,6 +4455,14 @@
         "tslib": "^1.10.0",
         "urijs": "^1.19.1",
         "utility-types": "^3.7.0"
+      },
+      "dependencies": {
+        "toml": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+          "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
+          "dev": true
+        }
       }
     },
     "stream-browserify": {
@@ -4681,10 +4689,9 @@
       "dev": true
     },
     "toml": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
-      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "tslib": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "hooks": {
       "pre-commit": "pretty-quick --staged"
     }
+  },
+  "dependencies": {
+    "toml": "^3.0.0"
   }
 }

--- a/src/components/wallet/events/render.tsx
+++ b/src/components/wallet/events/render.tsx
@@ -4,12 +4,12 @@ import loggedInContent from '../views/loggedInContent'
 import loggedOutContent from '../views/loggedOutContent'
 
 export default function () {
-  const confirmationPrompt = this.promptContents ? (
+  const popup = this.promptContents ? (
     <div class="popup">{this.promptContents}</div>
   ) : null
   return [
     <stellar-prompt prompter={this.prompter} />,
-    confirmationPrompt,
+    popup,
     this.account ? loggedInContent.call(this) : loggedOutContent.call(this),
     this.error ? (
       <pre class="error">{JSON.stringify(this.error, null, 2)}</pre>

--- a/src/components/wallet/events/render.tsx
+++ b/src/components/wallet/events/render.tsx
@@ -5,7 +5,9 @@ import loggedOutContent from '../views/loggedOutContent'
 
 export default function () {
   const popup = this.promptContents ? (
-    <div class="popup">{this.promptContents}</div>
+    <div class="popup-scrim">
+      <div class="popup">{this.promptContents}</div>
+    </div>
   ) : null
   return [
     <stellar-prompt prompter={this.prompter} />,

--- a/src/components/wallet/methods/makePayment.ts
+++ b/src/components/wallet/methods/makePayment.ts
@@ -18,7 +18,6 @@ export default async function makePayment(
   issuer?: string
 ) {
   try {
-    this.promptContents = 'HELLO'
     if (!destination)
       destination = await this.setPrompt({ message: 'Destination address' })
 

--- a/src/components/wallet/methods/makePayment.ts
+++ b/src/components/wallet/methods/makePayment.ts
@@ -50,8 +50,8 @@ export default async function makePayment(
     )
 
     this.error = null
-    this.loading = { ...this.loading, pay: true }
-
+    const loadingKey = `send:${assetCode}:${issuer}`
+    this.loading = { ...this.loading, [loadingKey]: true }
     const asset =
       assetCode === 'XLM' ? Asset.native() : new Asset(assetCode, issuer)
 
@@ -106,7 +106,7 @@ export default async function makePayment(
       })
       .then((res) => console.log(res))
       .finally(() => {
-        this.loading = { ...this.loading, pay: false }
+        this.loading = { ...this.loading, [loadingKey]: false }
         this.updateAccount()
       })
   } catch (err) {

--- a/src/components/wallet/methods/makeRegulatedPayment.ts
+++ b/src/components/wallet/methods/makeRegulatedPayment.ts
@@ -1,0 +1,165 @@
+import {
+  Account,
+  TransactionBuilder,
+  BASE_FEE,
+  Transaction,
+  Networks,
+  Operation,
+  Server,
+  Asset,
+  xdr,
+} from 'stellar-sdk'
+import TOML from 'toml'
+import { has as loHas } from 'lodash-es'
+
+import { handleError } from '@services/error'
+import { stretchPincode } from '@services/argon2'
+import { decrypt } from '@services/tweetnacl'
+
+function makeTransactionSummary(tx: Transaction): string {
+  const opMessages = tx.operations.map((operation) => {
+    switch (operation.type) {
+      case 'allowTrust':
+        return `<div>
+        ${operation.authorize ? 'Authorize' : 'Deauthorize'} ${
+          operation.assetCode
+        } access for ${operation.trustor.substr(0, 6)}
+        </div>`
+      case 'payment':
+        return `<div>
+          ${(operation.source || tx.source).substr(0, 6)}
+          pays ${operation.destination.substr(0, 6)}
+          ${parseFloat(operation.amount).toFixed(2)}
+          ${operation.asset.code}
+        </div>`
+      default:
+        return `<div>Unknown op type: <pre>${JSON.stringify(
+          operation,
+          null,
+          2
+        )}</pre></div>`
+    }
+  })
+
+  return `<div class="popup-code-set code-set">${opMessages.join('\n')}</div>`
+}
+
+export default async function makeRegulatedPayment(
+  destination?: string,
+  assetCode?: string,
+  issuer?: string
+) {
+  try {
+    const server = this.server as Server
+    if (!destination)
+      destination = await this.setPrompt({ message: 'Destination address' })
+
+    if (!assetCode || (!issuer && assetCode !== 'XLM')) {
+      const assetAndIssuer = await this.setPrompt({
+        message: '{Asset} {Issuer} (leave empty for XLM)',
+      })
+
+      if (assetAndIssuer === '') assetCode = 'XLM'
+      else [assetCode, issuer] = assetAndIssuer.split(' ')
+    }
+
+    const amount = await this.setPrompt({
+      message: `How much ${assetCode} to pay?`,
+    })
+
+    const loadingKey = `sendRegulated:${assetCode}:${issuer}`
+    this.loading = { ...this.loading, [loadingKey]: true }
+
+    const pincode = await this.setPrompt({
+      message: 'Enter your account pincode',
+      type: 'password',
+    })
+    const pincode_stretched = await stretchPincode(
+      pincode,
+      this.account.publicKey
+    )
+
+    const keypair = decrypt(
+      this.account.cipher,
+      this.account.nonce,
+      pincode_stretched
+    )
+
+    this.error = null
+
+    const asset =
+      assetCode === 'XLM' ? Asset.native() : new Asset(assetCode, issuer)
+    const issuerAccount = await server.loadAccount(issuer)
+    const homeDomain: string = (issuerAccount as any).home_domain
+    const tomlURL = new URL(homeDomain)
+    tomlURL.pathname = '/.well-known/stellar.toml'
+    const tomlText = await fetch(tomlURL.toString()).then((r) => r.text())
+    const toml = TOML.parse(tomlText)
+    const tomlCurrency = toml.CURRENCIES.find((c) => c.code === assetCode)
+    if (!tomlCurrency || !tomlCurrency.approval_server)
+      throw 'No approval server for asset'
+    const approvalServer = tomlCurrency.approval_server
+    console.log('Found approval server: ' + approvalServer)
+
+    const account = await server.loadAccount(keypair.publicKey())
+    const transaction = new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase: Networks.TESTNET,
+    })
+      .addOperation(
+        Operation.payment({
+          destination,
+          amount,
+          asset,
+        })
+      )
+      .setTimeout(30)
+      .build()
+    console.log('Built a transaction to request approval for:' + transaction)
+    const approvalUrl = new URL(approvalServer)
+    approvalUrl.searchParams.set('tx', transaction.toXDR())
+    const json = await fetch(approvalUrl.toString()).then((resp) => resp.json())
+    console.log(json)
+    console.log('Response from approval server: ' + json.status)
+
+    //@ts-ignore
+    const revisedEnvelope = xdr.TransactionEnvelope.fromXDR(json.tx, 'base64')
+    const revisedTx = new Transaction(revisedEnvelope, Networks.TESTNET)
+    console.log(
+      '<b>Revised Transaction from compliance server</b>' +
+        makeTransactionSummary(revisedTx)
+    )
+    try {
+      await this.setPrompt(
+        'Confirm revised transaction from compliance server?',
+        'Just press ok or cancel',
+        null,
+        makeTransactionSummary(revisedTx)
+      )
+    } catch (e) {
+      console.log('❌ Not signing the revised transaction, nothing happens')
+      this.loading = { ...this.loading, [loadingKey]: false }
+      return
+    }
+    const tx = new Transaction(revisedEnvelope, Networks.TESTNET)
+    tx.sign(keypair)
+    const labURL = `https://www.stellar.org/laboratory/#xdr-viewer?input=${encodeURIComponent(
+      tx.toXDR()
+    )}`
+    console.log(
+      `Submitting <a href="${labURL}" target="_blank">Signed Transaction (Open in stellar lab)</a>`
+    )
+
+    const { hash: txHash } = await server.submitTransaction(tx)
+    console.log(
+      `✅ Succesfully submitted regulated payment in transaction <a href="https://stellar.expert/explorer/testnet/tx/${txHash}" target="_blank">${txHash.substr(
+        0,
+        8
+      )}</a>!`
+    )
+
+    this.loading = { ...this.loading, [loadingKey]: false }
+  } catch (err) {
+    this.error = handleError(err)
+  }
+}

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -1,3 +1,4 @@
+import { Component, Prop, Element, Watch, h, State } from '@stencil/core'
 import {
   Account,
   TransactionBuilder,
@@ -129,14 +130,22 @@ export default async function makeRegulatedPayment(
       '<b>Revised Transaction from compliance server</b>' +
         makeTransactionSummary(revisedTx)
     )
+    console.log('YES')
     try {
-      await this.setPrompt(
-        'Confirm revised transaction from compliance server?',
-        'Just press ok or cancel',
-        null,
-        makeTransactionSummary(revisedTx)
-      )
+      await new Promise((res, rej) => {
+        this.promptContents = (
+          <div>
+            <div innerHTML={makeTransactionSummary(revisedTx)}></div>
+            <div>
+              <button onClick={rej}>Cancel</button>
+              <button onClick={res}>Confirm</button>
+            </div>
+          </div>
+        )
+      })
+      this.promptContents = null
     } catch (e) {
+      this.promptContents = null
       console.log('❌ Not signing the revised transaction, nothing happens')
       this.loading = { ...this.loading, [loadingKey]: false }
       return
@@ -159,6 +168,7 @@ export default async function makeRegulatedPayment(
     )
 
     this.loading = { ...this.loading, [loadingKey]: false }
+    this.updateAccount()
   } catch (err) {
     this.error = handleError(err)
   }

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -79,19 +79,11 @@ export default async function makeRegulatedPayment(
       fee: '100',
       networkPassphrase: Networks.TESTNET,
     })
-      // .addOperation(
-      //   Operation.payment({
-      //     destination,
-      //     amount,
-      //     asset,
-      //   })
-      // )
       .addOperation(
-        Operation.manageBuyOffer({
-          buyAmount: '33',
-          selling: Asset.native(),
-          buying: asset,
-          price: '100',
+        Operation.payment({
+          destination,
+          amount,
+          asset,
         })
       )
       .setTimeout(30)

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -43,7 +43,12 @@ function makeTransactionSummary(tx: Transaction): HTMLElement {
     }
   })
 
-  return <div class="popup-code-set code-set">{opMessages}</div>
+  return (
+    <div class="popup-code-set code-set">
+      <h3>Approve revised transaction from approval server?</h3>
+      {opMessages}
+    </div>
+  )
 }
 
 export default async function makeRegulatedPayment(

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -121,7 +121,6 @@ export default async function makeRegulatedPayment(
     const approvalUrl = new URL(approvalServer)
     approvalUrl.searchParams.set('tx', transaction.toXDR())
     const json = await fetch(approvalUrl.toString()).then((resp) => resp.json())
-    console.log(json)
     console.log('Response from approval server: ' + json.status)
 
     //@ts-ignore

--- a/src/components/wallet/methods/popup.tsx
+++ b/src/components/wallet/methods/popup.tsx
@@ -1,0 +1,32 @@
+import { h } from '@stencil/core'
+
+export interface PopupContents {
+  contents: HTMLElement
+  confirmLabel?: string
+  cancelLabel?: string
+}
+const popup = async function (popup: PopupContents) {
+  try {
+    await new Promise((res, rej) => {
+      const cancelButton = popup.cancelLabel ? (
+        <button onClick={rej}>{popup.cancelLabel}</button>
+      ) : null
+      const confirmButton = popup.confirmLabel ? (
+        <button onClick={res}>{popup.confirmLabel}</button>
+      ) : null
+      this.promptContents = (
+        <div>
+          <div>{popup.contents}</div>
+          <div class="button-row">
+            {cancelButton}
+            {confirmButton}
+          </div>
+        </div>
+      )
+    })
+  } finally {
+    this.promptContents = null
+  }
+}
+
+export default popup

--- a/src/components/wallet/views/balanceDisplay.tsx
+++ b/src/components/wallet/views/balanceDisplay.tsx
@@ -11,20 +11,44 @@ interface Balance {
 
 export default function balanceDisplay() {
   const balanceRow = (balance: Balance) => {
+    const isRegulated =
+      !balance.is_authorized && balance.asset_type !== 'native'
     const assetCode =
       balance.asset_type === 'native' ? 'XLM' : balance.asset_code
 
+    const sendLoadingState = this.loading[
+      `send:${balance.asset_code}:${balance.asset_issuer}`
+    ]
+    const sendButton = (
+      <button
+        class={sendLoadingState ? 'loading' : null}
+        onClick={() => this.makePayment(null, assetCode, balance.asset_issuer)}
+      >
+        {sendLoadingState ? <stellar-loader /> : null}
+        Send
+      </button>
+    )
+
+    const sendRegulatedLoadingState = this.loading[
+      `sendRegulated:${balance.asset_code}:${balance.asset_issuer}`
+    ]
+    const regulatedSendButton = !isRegulated ? null : (
+      <button
+        class={sendRegulatedLoadingState ? 'loading' : null}
+        onClick={() =>
+          this.makeRegulatedPayment(null, assetCode, balance.asset_issuer)
+        }
+      >
+        {sendRegulatedLoadingState ? <stellar-loader /> : null}
+        Send Regulated
+      </button>
+    )
     return (
       <div class="balance-row">
         <div class="asset-code">{assetCode}</div>
         <div class="balance">{balance.balance}</div>
-        <button
-          onClick={() =>
-            this.makePayment(null, assetCode, balance.asset_issuer)
-          }
-        >
-          Send
-        </button>
+        {sendButton}
+        {regulatedSendButton}
       </div>
     )
   }

--- a/src/components/wallet/views/transactionSummary.tsx
+++ b/src/components/wallet/views/transactionSummary.tsx
@@ -1,0 +1,39 @@
+import { h } from '@stencil/core'
+import { Transaction } from 'stellar-sdk'
+
+export default function TransactionSummary(tx: Transaction) {
+  const opMessages = tx.operations.map((operation) => {
+    switch (operation.type) {
+      case 'allowTrust':
+        return (
+          <div>
+            {`${operation.authorize ? 'Authorize' : 'Deauthorize'} ${
+              operation.assetCode
+            } access for ${operation.trustor.substr(0, 6)}`}
+          </div>
+        )
+      case 'payment':
+        return (
+          <div>
+            {`${(operation.source || tx.source).substr(0, 6)}
+            pays ${operation.destination.substr(0, 6)} ${parseFloat(
+              operation.amount
+            ).toFixed(2)} ${operation.asset.code}`}
+          </div>
+        )
+      default:
+        return (
+          <div>
+            Unknown op type: <pre>${JSON.stringify(operation, null, 2)}</pre>
+          </div>
+        )
+    }
+  })
+
+  return (
+    <div class="popup-code-set code-set">
+      <h3>Approve revised transaction from approval server?</h3>
+      {opMessages}
+    </div>
+  )
+}

--- a/src/components/wallet/wallet.scss
+++ b/src/components/wallet/wallet.scss
@@ -63,7 +63,7 @@
     position: absolute;
     top: 200px;
     left: calc(50% - 150px);
-    background: rgba(255, 255, 255, 0.7);
+    background: white;
     width: 300px;
     height: 200px;
     z-index: 100;

--- a/src/components/wallet/wallet.scss
+++ b/src/components/wallet/wallet.scss
@@ -58,14 +58,22 @@
     background-color: orangered;
     color: white;
   }
-
+  .popup-scrim {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 100;
+  }
   .popup {
     position: absolute;
     top: 200px;
     left: calc(50% - 150px);
     background: white;
     width: 400px;
-    z-index: 100;
+
     padding: 8px;
     border: 1px solid black;
 

--- a/src/components/wallet/wallet.scss
+++ b/src/components/wallet/wallet.scss
@@ -64,10 +64,20 @@
     top: 200px;
     left: calc(50% - 150px);
     background: white;
-    width: 300px;
-    height: 200px;
+    width: 400px;
     z-index: 100;
+    padding: 8px;
     border: 1px solid black;
+
+    .button-row {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-end;
+
+      button {
+        margin: 4px;
+      }
+    }
   }
 
   stellar-loader {

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -16,6 +16,7 @@ import copySecret from './methods/copySecret'
 import signOut from './methods/signOut'
 import setPrompt from './methods/setPrompt'
 import loadAccount from './methods/loadAccount'
+import popup from './methods/popup'
 
 import { Prompter } from '@prompt/prompt'
 
@@ -71,6 +72,7 @@ export class Wallet {
 
   // Misc methods
   setPrompt = setPrompt
+  popup = popup
 }
 
 Wallet.prototype.componentWillLoad = componentWillLoad

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -10,6 +10,7 @@ import depositAsset from './methods/depositAsset' // NEW
 import withdrawAsset from './methods/withdrawAsset' // NEW
 import trustAsset from './methods/trustAsset'
 import makePayment from './methods/makePayment'
+import makeRegulatedPayment from './methods/makeRegulatedPayment'
 import copyAddress from './methods/copyAddress'
 import copySecret from './methods/copySecret'
 import signOut from './methods/signOut'
@@ -62,6 +63,7 @@ export class Wallet {
   withdrawAsset = withdrawAsset // NEW
   trustAsset = trustAsset
   makePayment = makePayment
+  makeRegulatedPayment = makeRegulatedPayment
   copyAddress = copyAddress
   copySecret = copySecret
   signOut = signOut


### PR DESCRIPTION
Implement the SEP-8 bridge interactions needed to support regulated assets.
Create a simpler 'popup' class that can put arbitrary contents into an awaitable popup
Make the individual send buttons have spinners instead of just only allowing one spinner on the make payment button

Fixes #110
