### PR TITLE
Add log view

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,6 +8,12 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Prompter, } from "./components/prompt/prompt";
 import { Server, } from "stellar-sdk";
 export namespace Components {
+    interface LogView {
+        "error": (text: string) => Promise<void>;
+        "instruction": (text: string) => Promise<void>;
+        "request": (url: any, body: any) => Promise<void>;
+        "response": (url: any, body: any) => Promise<void>;
+    }
     interface StellarLoader {
         "interval": any;
     }
@@ -21,6 +27,12 @@ export namespace Components {
     }
 }
 declare global {
+    interface HTMLLogViewElement extends Components.LogView, HTMLStencilElement {
+    }
+    var HTMLLogViewElement: {
+        prototype: HTMLLogViewElement;
+        new (): HTMLLogViewElement;
+    };
     interface HTMLStellarLoaderElement extends Components.StellarLoader, HTMLStencilElement {
     }
     var HTMLStellarLoaderElement: {
@@ -40,12 +52,15 @@ declare global {
         new (): HTMLStellarWalletElement;
     };
     interface HTMLElementTagNameMap {
+        "log-view": HTMLLogViewElement;
         "stellar-loader": HTMLStellarLoaderElement;
         "stellar-prompt": HTMLStellarPromptElement;
         "stellar-wallet": HTMLStellarWalletElement;
     }
 }
 declare namespace LocalJSX {
+    interface LogView {
+    }
     interface StellarLoader {
         "interval"?: any;
     }
@@ -58,6 +73,7 @@ declare namespace LocalJSX {
         "toml"?: Object;
     }
     interface IntrinsicElements {
+        "log-view": LogView;
         "stellar-loader": StellarLoader;
         "stellar-prompt": StellarPrompt;
         "stellar-wallet": StellarWallet;
@@ -67,6 +83,7 @@ export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
+            "log-view": LocalJSX.LogView & JSXBase.HTMLAttributes<HTMLLogViewElement>;
             "stellar-loader": LocalJSX.StellarLoader & JSXBase.HTMLAttributes<HTMLStellarLoaderElement>;
             "stellar-prompt": LocalJSX.StellarPrompt & JSXBase.HTMLAttributes<HTMLStellarPromptElement>;
             "stellar-wallet": LocalJSX.StellarWallet & JSXBase.HTMLAttributes<HTMLStellarWalletElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,8 +13,8 @@ export namespace Components {
         "showText": string;
     }
     interface LogView {
-        "error": (text: string) => Promise<void>;
-        "instruction": (text: string) => Promise<void>;
+        "error": (title: string, body: string) => Promise<void>;
+        "instruction": (title: string, body: string) => Promise<void>;
         "request": (url: any, body: any) => Promise<void>;
         "response": (url: any, body: any) => Promise<void>;
     }

--- a/src/components/logview/assets/arrow-left.svg
+++ b/src/components/logview/assets/arrow-left.svg
@@ -1,0 +1,4 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 5.99997H1" stroke="#84D128" stroke-width="1.42857" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 1L1 6L6 11" stroke="#84D128" stroke-width="1.42857" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/logview/assets/arrow-right.svg
+++ b/src/components/logview/assets/arrow-right.svg
@@ -1,0 +1,4 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 5.99997H11" stroke="#FF8900" stroke-width="1.42857" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6 1L11 6L6 11" stroke="#FF8900" stroke-width="1.42857" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/logview/assets/error.svg
+++ b/src/components/logview/assets/error.svg
@@ -1,0 +1,11 @@
+<svg width="15px" height="15px" viewBox="0 0 15 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="message-icon-copy-2" transform="translate(1.000000, 1.000000)" stroke="#D0021B" stroke-width="1.5">
+            <g id="x-octagon">
+                <polygon id="Path" points="3.809 0 9.191 0 13 3.809 13 9.191 9.191 13 3.809 13 0 9.191 0 3.809"></polygon>
+                <path d="M8.45,4.55 L4.55,8.45" id="Path"></path>
+                <path d="M4.55,4.55 L8.45,8.45" id="Path"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/logview/assets/message.svg
+++ b/src/components/logview/assets/message.svg
@@ -1,0 +1,5 @@
+<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M14 9.66667C14 10.4644 13.3533 11.1111 12.5556 11.1111H3.88889L1 14V2.44444C1 1.6467 1.6467 1 2.44444 1H12.5556C13.3533 1 14 1.6467 14 2.44444V9.66667Z" stroke="#00AA46" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 4.5H10.7321" stroke="#00AA46" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4 7.5H10.7321" stroke="#00AA46" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/logview/logview.scss
+++ b/src/components/logview/logview.scss
@@ -4,8 +4,10 @@ $arrow-right: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIi
 $error-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTVweCIgaGVpZ2h0PSIxNXB4IiB2aWV3Qm94PSIwIDAgMTUgMTUiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8ZyBpZD0iU3ltYm9scyIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj4KICAgICAgICA8ZyBpZD0ibWVzc2FnZS1pY29uLWNvcHktMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMS4wMDAwMDAsIDEuMDAwMDAwKSIgc3Ryb2tlPSIjRDAwMjFCIiBzdHJva2Utd2lkdGg9IjEuNSI+CiAgICAgICAgICAgIDxnIGlkPSJ4LW9jdGFnb24iPgogICAgICAgICAgICAgICAgPHBvbHlnb24gaWQ9IlBhdGgiIHBvaW50cz0iMy44MDkgMCA5LjE5MSAwIDEzIDMuODA5IDEzIDkuMTkxIDkuMTkxIDEzIDMuODA5IDEzIDAgOS4xOTEgMCAzLjgwOSI+PC9wb2x5Z29uPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTguNDUsNC41NSBMNC41NSw4LjQ1IiBpZD0iUGF0aCI+PC9wYXRoPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTQuNTUsNC41NSBMOC40NSw4LjQ1IiBpZD0iUGF0aCI+PC9wYXRoPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=);
 
 .logview {
+  position: relative;
   padding: 8px;
   background: #eee;
+  min-height: 32px;
 }
 
 .entry {
@@ -29,14 +31,20 @@ $error-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTVweCIgaGVpZ2h0PSIxN
 .instruction,
 .error {
   padding: 8px;
-  padding-left: 32px;
 }
 
-.instruction {
+.instruction .title,
+.error .title {
+  padding-left: 32px;
   background: white $message-icon no-repeat 8px center;
 }
 
-.error {
+.instruction .body,
+.error .body {
+  padding: 8px 32px;
+}
+
+.error .title {
   background: white $error-icon no-repeat 8px center;
 }
 
@@ -64,4 +72,10 @@ $error-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTVweCIgaGVpZ2h0PSIxN
 
 .response .title {
   background-image: $arrow-left;
+}
+
+.clear-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
 }

--- a/src/components/logview/logview.scss
+++ b/src/components/logview/logview.scss
@@ -1,0 +1,67 @@
+$message-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTUiIGhlaWdodD0iMTUiIHZpZXdCb3g9IjAgMCAxNSAxNSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0xNCA5LjY2NjY3QzE0IDEwLjQ2NDQgMTMuMzUzMyAxMS4xMTExIDEyLjU1NTYgMTEuMTExMUgzLjg4ODg5TDEgMTRWMi40NDQ0NEMxIDEuNjQ2NyAxLjY0NjcgMSAyLjQ0NDQ0IDFIMTIuNTU1NkMxMy4zNTMzIDEgMTQgMS42NDY3IDE0IDIuNDQ0NDRWOS42NjY2N1oiIHN0cm9rZT0iIzAwQUE0NiIgc3Ryb2tlLXdpZHRoPSIxLjUiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8cGF0aCBkPSJNNCA0LjVIMTAuNzMyMSIgc3Ryb2tlPSIjMDBBQTQ2IiBzdHJva2Utd2lkdGg9IjEuNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+CjxwYXRoIGQ9Ik00IDcuNUgxMC43MzIxIiBzdHJva2U9IiMwMEFBNDYiIHN0cm9rZS13aWR0aD0iMS41IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KPC9zdmc+Cg==);
+$arrow-left: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTExIDUuOTk5OTdIMSIgc3Ryb2tlPSIjODREMTI4IiBzdHJva2Utd2lkdGg9IjEuNDI4NTciIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8cGF0aCBkPSJNNiAxTDEgNkw2IDExIiBzdHJva2U9IiM4NEQxMjgiIHN0cm9rZS13aWR0aD0iMS40Mjg1NyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIi8+Cjwvc3ZnPgo=);
+$arrow-right: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTEgNS45OTk5N0gxMSIgc3Ryb2tlPSIjRkY4OTAwIiBzdHJva2Utd2lkdGg9IjEuNDI4NTciIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8cGF0aCBkPSJNNiAxTDExIDZMNiAxMSIgc3Ryb2tlPSIjRkY4OTAwIiBzdHJva2Utd2lkdGg9IjEuNDI4NTciIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4K);
+$error-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTVweCIgaGVpZ2h0PSIxNXB4IiB2aWV3Qm94PSIwIDAgMTUgMTUiIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8ZyBpZD0iU3ltYm9scyIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIj4KICAgICAgICA8ZyBpZD0ibWVzc2FnZS1pY29uLWNvcHktMiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMS4wMDAwMDAsIDEuMDAwMDAwKSIgc3Ryb2tlPSIjRDAwMjFCIiBzdHJva2Utd2lkdGg9IjEuNSI+CiAgICAgICAgICAgIDxnIGlkPSJ4LW9jdGFnb24iPgogICAgICAgICAgICAgICAgPHBvbHlnb24gaWQ9IlBhdGgiIHBvaW50cz0iMy44MDkgMCA5LjE5MSAwIDEzIDMuODA5IDEzIDkuMTkxIDkuMTkxIDEzIDMuODA5IDEzIDAgOS4xOTEgMCAzLjgwOSI+PC9wb2x5Z29uPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTguNDUsNC41NSBMNC41NSw4LjQ1IiBpZD0iUGF0aCI+PC9wYXRoPgogICAgICAgICAgICAgICAgPHBhdGggZD0iTTQuNTUsNC41NSBMOC40NSw4LjQ1IiBpZD0iUGF0aCI+PC9wYXRoPgogICAgICAgICAgICA8L2c+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4=);
+
+.logview {
+  padding: 8px;
+  background: #eee;
+}
+
+.entry {
+  margin-top: 8px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.entry {
+  .title {
+    background-color: #ddd;
+    padding: 8px;
+  }
+
+  .body {
+    padding: 8px;
+    background: #fff;
+  }
+}
+
+.instruction,
+.error {
+  padding: 8px;
+  padding-left: 32px;
+}
+
+.instruction {
+  background: white $message-icon no-repeat 8px center;
+}
+
+.error {
+  background: white $error-icon no-repeat 8px center;
+}
+
+.request,
+.response {
+  margin-left: 16px;
+  color: white;
+
+  .title {
+    background-color: #474e62;
+    padding-left: 32px;
+    background-position: 8px center;
+    background-repeat: no-repeat;
+  }
+
+  .body {
+    background-color: #4d556d;
+    white-space: pre;
+  }
+}
+
+.request .title {
+  background-image: $arrow-right;
+}
+
+.response .title {
+  background-image: $arrow-left;
+}

--- a/src/components/logview/logview.tsx
+++ b/src/components/logview/logview.tsx
@@ -9,6 +9,7 @@ enum LogDataType {
 interface LogData {
   type: LogDataType
   url?: string
+  title?: string
   body?: string
 }
 
@@ -37,38 +38,63 @@ export class LogView {
   }
 
   @Method()
-  async instruction(text: string) {
-    console.log('Instruction', text)
-    this.append({ type: LogDataType.Instruction, body: text })
+  async instruction(title: string, body: string) {
+    console.log('Instruction', title, body)
+    this.append({ type: LogDataType.Instruction, title, body })
   }
 
   @Method()
-  async error(text: string) {
-    console.error(text)
-    this.append({ type: LogDataType.Error, body: text })
+  async error(title: string, body: string) {
+    console.error(title, body)
+    this.append({ type: LogDataType.Error, title, body })
+  }
+
+  clear() {
+    this.logs = []
   }
 
   transformToElement(data: LogData) {
     switch (data.type) {
       case LogDataType.Instruction:
-        return <div class="instruction entry">{data.body}</div>
+        return (
+          <div class="instruction entry">
+            <div class="title">{data.title}</div>
+            {data.body ? <div class="body">{data.body}</div> : null}
+          </div>
+        )
+
       case LogDataType.Error:
-        return <div class="error entry">{data.body}</div>
+        return (
+          <div class="error entry">
+            <div class="title">{data.title}</div>
+            {data.body ? <div class="body">{data.body}</div> : null}
+          </div>
+        )
+
       case LogDataType.Request:
+        const requestBody =
+          typeof data.body == 'string'
+            ? data.body
+            : JSON.stringify(data.body, null, 2)
         return (
           <div class="request entry">
             <div class="title">{data.url}</div>
-            <div class="body">{JSON.stringify(data.body, null, 2)}</div>
+            <div class="body">{requestBody}</div>
           </div>
         )
 
       case LogDataType.Response:
+        const responseBody =
+          typeof data.body == 'string'
+            ? data.body
+            : JSON.stringify(data.body, null, 2)
         return (
           <div class="response entry">
             <div class="title">{data.url}</div>
-            <div class="body">{JSON.stringify(data.body, null, 2)}</div>
+            <div class="body">{responseBody}</div>
           </div>
         )
+
       default:
         return null
     }
@@ -77,7 +103,9 @@ export class LogView {
   render() {
     return (
       <div class="logview">
-        <h1>Log View</h1>
+        <button class="clear-button" onClick={(_) => this.clear()}>
+          Clear
+        </button>
         {this.logs.map((l) => this.transformToElement(l))}
       </div>
     )

--- a/src/components/logview/logview.tsx
+++ b/src/components/logview/logview.tsx
@@ -1,4 +1,4 @@
-import { Component, h, State, Method, getAssetPath } from '@stencil/core'
+import { Component, h, State, Method } from '@stencil/core'
 
 enum LogDataType {
   Instruction = 1,
@@ -19,15 +19,6 @@ interface LogData {
 })
 export class LogView {
   @State() logs: LogData[] = []
-
-  componentWillLoad() {
-    console.log(getAssetPath('/assets/message.svg'))
-    this.instruction('This is an instruction')
-    this.error('This is an error')
-    this.request('http://www.google.com', { data: { a: 1, b: 2 } })
-    this.response('http://www.google.com', { data: { a: 1, b: 2 } })
-    console.log(this.logs)
-  }
 
   append(data: LogData) {
     this.logs = [...this.logs, data]

--- a/src/components/logview/logview.tsx
+++ b/src/components/logview/logview.tsx
@@ -1,0 +1,92 @@
+import { Component, h, State, Method, getAssetPath } from '@stencil/core'
+
+enum LogDataType {
+  Instruction = 1,
+  Request,
+  Response,
+  Error,
+}
+interface LogData {
+  type: LogDataType
+  url?: string
+  body?: string
+}
+
+@Component({
+  tag: 'log-view',
+  styleUrl: 'logview.scss',
+  shadow: true,
+})
+export class LogView {
+  @State() logs: LogData[] = []
+
+  componentWillLoad() {
+    console.log(getAssetPath('/assets/message.svg'))
+    this.instruction('This is an instruction')
+    this.error('This is an error')
+    this.request('http://www.google.com', { data: { a: 1, b: 2 } })
+    this.response('http://www.google.com', { data: { a: 1, b: 2 } })
+    console.log(this.logs)
+  }
+
+  append(data: LogData) {
+    this.logs = [...this.logs, data]
+  }
+
+  @Method()
+  async request(url, body) {
+    console.log('Request', url, body)
+    this.append({ type: LogDataType.Request, url, body })
+  }
+
+  @Method()
+  async response(url, body) {
+    console.log('Response', url, body)
+    this.append({ type: LogDataType.Response, url, body })
+  }
+
+  @Method()
+  async instruction(text: string) {
+    this.append({ type: LogDataType.Instruction, body: text })
+  }
+
+  @Method()
+  async error(text: string) {
+    this.append({ type: LogDataType.Error, body: text })
+  }
+
+  transformToElement(data: LogData) {
+    switch (data.type) {
+      case LogDataType.Instruction:
+        return <div class="instruction entry">{data.body}</div>
+      case LogDataType.Error:
+        return <div class="error entry">{data.body}</div>
+      case LogDataType.Request:
+        return (
+          <div class="request entry">
+            <div class="title">{data.url}</div>
+            <div class="body">{JSON.stringify(data.body, null, 2)}</div>
+          </div>
+        )
+
+      case LogDataType.Response:
+        return (
+          <div class="response entry">
+            <div class="title">{data.url}</div>
+            <div class="body">{JSON.stringify(data.body, null, 2)}</div>
+          </div>
+        )
+      default:
+        return null
+    }
+  }
+
+  render() {
+    return (
+      <div class="logview">
+        <h1>Log View</h1>
+        {this.logs.map((l) => this.transformToElement(l))}
+      </div>
+    )
+  }
+}

--- a/src/components/logview/logview.tsx
+++ b/src/components/logview/logview.tsx
@@ -38,11 +38,13 @@ export class LogView {
 
   @Method()
   async instruction(text: string) {
+    console.log('Instruction', text)
     this.append({ type: LogDataType.Instruction, body: text })
   }
 
   @Method()
   async error(text: string) {
+    console.error(text)
     this.append({ type: LogDataType.Error, body: text })
   }
 

--- a/src/components/logview/readme.md
+++ b/src/components/logview/readme.md
@@ -1,0 +1,66 @@
+# log-view
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Methods
+
+### `error(text: string) => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `instruction(text: string) => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `request(url: any, body: any) => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+### `response(url: any, body: any) => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Dependencies
+
+### Used by
+
+ - [stellar-wallet](../wallet)
+
+### Graph
+```mermaid
+graph TD;
+  stellar-wallet --> log-view
+  style log-view fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/logview/readme.md
+++ b/src/components/logview/readme.md
@@ -7,7 +7,7 @@
 
 ## Methods
 
-### `error(text: string) => Promise<void>`
+### `error(title: string, body: string) => Promise<void>`
 
 
 
@@ -17,7 +17,7 @@ Type: `Promise<void>`
 
 
 
-### `instruction(text: string) => Promise<void>`
+### `instruction(title: string, body: string) => Promise<void>`
 
 
 

--- a/src/components/wallet/events/render.tsx
+++ b/src/components/wallet/events/render.tsx
@@ -6,9 +6,9 @@ import loggedOutContent from '../views/loggedOutContent'
 export default function () {
   return [
     <stellar-prompt prompter={this.prompter} />,
+    <log-view ref={(el) => (this.logger = el)}></log-view>,
 
     this.account ? loggedInContent.call(this) : loggedOutContent.call(this),
-
     this.error ? (
       <pre class="error">{JSON.stringify(this.error, null, 2)}</pre>
     ) : null,

--- a/src/components/wallet/events/render.tsx
+++ b/src/components/wallet/events/render.tsx
@@ -13,7 +13,9 @@ export default function () {
     <stellar-prompt prompter={this.prompter} />,
     popup,
     this.account ? loggedInContent.call(this) : loggedOutContent.call(this),
-    <log-view ref={(el) => (this.logger = el)}></log-view>,
+    <collapsible-container show-text="Show Logs" hide-text="Hide Logs">
+      <log-view ref={(el) => (this.logger = el)}></log-view>
+    </collapsible-container>,
     this.error ? (
       <pre class="error">{JSON.stringify(this.error, null, 2)}</pre>
     ) : null,

--- a/src/components/wallet/methods/copyAddress.ts
+++ b/src/components/wallet/methods/copyAddress.ts
@@ -2,4 +2,5 @@ import copy from 'copy-to-clipboard'
 
 export default async function copyAddress() {
   copy(this.account.publicKey)
+  this.logger.instruction('Copying public key ' + this.account.publicKey)
 }

--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -35,11 +35,10 @@ export default async function depositAsset() {
 
     if (hasCurrency === -1)
       await this.trustAsset(currency[0], currency[1], pincode_stretched)
-
-    const info = await axios
-      .get(`${this.toml.TRANSFER_SERVER_SEP0024}/info`)
-      .then(({ data }) => data)
-
+    const infoURL = `${this.toml.TRANSFER_SERVER_SEP0024}/info`
+    this.logger.request(infoURL)
+    const info = await axios.get(infoURL).then(({ data }) => data)
+    this.logger.response(infoURL, info)
     console.log(info)
 
     const auth = await axios

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -144,9 +144,7 @@ export default async function makeRegulatedPayment(
         cancelLabel: 'Reject',
       })
     } catch (e) {
-      this.logger.error(
-        '❌ Not signing the revised transaction, nothing happens'
-      )
+      this.logger.error('Not signing the revised transaction, nothing happens')
       await this.popup({
         contents: (
           <div>❌ Not signing the revised transaction, nothing happens</div>

--- a/src/components/wallet/readme.md
+++ b/src/components/wallet/readme.md
@@ -17,17 +17,17 @@
 ### Depends on
 
 - [stellar-prompt](../prompt)
+- [collapsible-container](views)
 - [log-view](../logview)
 - [stellar-loader](../loader)
-- [collapsible-container](views)
 
 ### Graph
 ```mermaid
 graph TD;
   stellar-wallet --> stellar-prompt
+  stellar-wallet --> collapsible-container
   stellar-wallet --> log-view
   stellar-wallet --> stellar-loader
-  stellar-wallet --> collapsible-container
   style stellar-wallet fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/wallet/readme.md
+++ b/src/components/wallet/readme.md
@@ -17,12 +17,14 @@
 ### Depends on
 
 - [stellar-prompt](../prompt)
+- [log-view](../logview)
 - [stellar-loader](../loader)
 
 ### Graph
 ```mermaid
 graph TD;
   stellar-wallet --> stellar-prompt
+  stellar-wallet --> log-view
   stellar-wallet --> stellar-loader
   style stellar-wallet fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/wallet/views/collapsibleContainer.tsx
+++ b/src/components/wallet/views/collapsibleContainer.tsx
@@ -14,7 +14,7 @@ export class CollapsibleContainer {
   render() {
     return (
       <div>
-        <button onClick={(e) => this.handleClick()}>
+        <button onClick={() => this.handleClick()}>
           {this.open ? this.hideText : this.showText}
         </button>
         <div style={{ display: this.open ? 'block' : 'none' }}>

--- a/src/components/wallet/views/transactionSummary.tsx
+++ b/src/components/wallet/views/transactionSummary.tsx
@@ -30,10 +30,5 @@ export default function TransactionSummary(tx: Transaction) {
     }
   })
 
-  return (
-    <div class="popup-code-set code-set">
-      <h3>Approve revised transaction from approval server?</h3>
-      {opMessages}
-    </div>
-  )
+  return <div class="popup-code-set code-set">{opMessages}</div>
 }

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -1,4 +1,4 @@
-import { Component, State, Prop, Element } from '@stencil/core'
+import { Component, State, Prop } from '@stencil/core'
 import { Server, ServerApi } from 'stellar-sdk'
 
 import componentWillLoad from './events/componentWillLoad' // UPDATE
@@ -43,9 +43,6 @@ interface Loading {
   shadow: true,
 })
 export class Wallet {
-  // @ts-ignore This is used in the prompter
-  @Element() private element: HTMLElement
-
   @State() account: StellarAccount
   @State() prompter: Prompter = { show: false }
   @State() loading: Loading = {}

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -1,4 +1,4 @@
-import { Component, State, Prop } from '@stencil/core'
+import { Component, State, Prop, Element } from '@stencil/core'
 import { Server, ServerApi } from 'stellar-sdk'
 
 import componentWillLoad from './events/componentWillLoad' // UPDATE
@@ -41,6 +41,8 @@ interface Loading {
   shadow: true,
 })
 export class Wallet {
+  @Element() private element: HTMLElement
+
   @State() account: StellarAccount
   @State() prompter: Prompter = { show: false }
   @State() loading: Loading = {}
@@ -53,6 +55,8 @@ export class Wallet {
   // Component events
   componentWillLoad() {}
   render() {}
+
+  logger!: HTMLLogViewElement
 
   // Stellar methods
   createAccount = createAccount

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -43,6 +43,7 @@ interface Loading {
   shadow: true,
 })
 export class Wallet {
+  // @ts-ignore This is used in the prompter
   @Element() private element: HTMLElement
 
   @State() account: StellarAccount


### PR DESCRIPTION
Add a log view and the ability to create logs similar to our demo clients.
This PR will add the functions 
```
this.logger.instruction
this.logger.error
this.logger.request
this.logger.response
```
and will allow any other component in the wallet to add logs to this and create a nice logging log view for them.  We can instrument all of our capabilities with these functions and have nice user feedback for everything.  I've started by instrumenting the regulated assets flow.

![Screenshot 2020-06-26 at 1 56 51 PM](https://user-images.githubusercontent.com/161135/85900747-2d962680-b7b5-11ea-871a-b6eb1fac931a.png)
