### PR TITLE
Add 'fake this' to methods

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -25,7 +25,7 @@ export namespace Components {
         "prompter": Prompter;
     }
     interface StellarWallet {
-        "homeDomain": String;
+        "homeDomain": string;
         "server": Server;
         "toml": any;
     }
@@ -83,7 +83,7 @@ declare namespace LocalJSX {
         "prompter"?: Prompter;
     }
     interface StellarWallet {
-        "homeDomain"?: String;
+        "homeDomain"?: string;
         "server"?: Server;
         "toml"?: any;
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,10 +13,10 @@ export namespace Components {
         "showText": string;
     }
     interface LogView {
-        "error": (title: string, body: string) => Promise<void>;
-        "instruction": (title: string, body: string) => Promise<void>;
-        "request": (url: any, body: any) => Promise<void>;
-        "response": (url: any, body: any) => Promise<void>;
+        "error": (title: string, body?: string) => Promise<void>;
+        "instruction": (title: string, body?: string) => Promise<void>;
+        "request": (url: string, body?: string) => Promise<void>;
+        "response": (url: string, body?: string) => Promise<void>;
     }
     interface StellarLoader {
         "interval": any;
@@ -27,7 +27,7 @@ export namespace Components {
     interface StellarWallet {
         "homeDomain": String;
         "server": Server;
-        "toml": Object;
+        "toml": any;
     }
 }
 declare global {
@@ -85,7 +85,7 @@ declare namespace LocalJSX {
     interface StellarWallet {
         "homeDomain"?: String;
         "server"?: Server;
-        "toml"?: Object;
+        "toml"?: any;
     }
     interface IntrinsicElements {
         "collapsible-container": CollapsibleContainer;

--- a/src/components/logview/logview.tsx
+++ b/src/components/logview/logview.tsx
@@ -27,28 +27,28 @@ export class LogView {
 
   // Log an outgoing network request with a url and optional body
   @Method()
-  async request(url, body) {
+  async request(url: string, body?: string) {
     console.log('Request', url, body)
     this.append({ type: LogDataType.Request, url, body })
   }
 
   // Log the incoming response from a request
   @Method()
-  async response(url, body) {
+  async response(url: string, body?: string) {
     console.log('Response', url, body)
     this.append({ type: LogDataType.Response, url, body })
   }
 
   // Log an informational statement with a title and optional body
   @Method()
-  async instruction(title: string, body: string) {
+  async instruction(title: string, body?: string) {
     console.log('Instruction', title, body)
     this.append({ type: LogDataType.Instruction, title, body })
   }
 
   // Log an error with a title and optional body
   @Method()
-  async error(title: string, body: string) {
+  async error(title: string, body?: string) {
     console.error(title, body)
     this.append({ type: LogDataType.Error, title, body })
   }

--- a/src/components/logview/readme.md
+++ b/src/components/logview/readme.md
@@ -7,7 +7,7 @@
 
 ## Methods
 
-### `error(title: string, body: string) => Promise<void>`
+### `error(title: string, body?: string) => Promise<void>`
 
 
 
@@ -17,7 +17,7 @@ Type: `Promise<void>`
 
 
 
-### `instruction(title: string, body: string) => Promise<void>`
+### `instruction(title: string, body?: string) => Promise<void>`
 
 
 
@@ -27,7 +27,7 @@ Type: `Promise<void>`
 
 
 
-### `request(url: any, body: any) => Promise<void>`
+### `request(url: string, body?: string) => Promise<void>`
 
 
 
@@ -37,7 +37,7 @@ Type: `Promise<void>`
 
 
 
-### `response(url: any, body: any) => Promise<void>`
+### `response(url: string, body?: string) => Promise<void>`
 
 
 

--- a/src/components/wallet/events/componentWillLoad.ts
+++ b/src/components/wallet/events/componentWillLoad.ts
@@ -1,8 +1,9 @@
 import { StellarTomlResolver } from 'stellar-sdk'
 import { handleError } from '@services/error'
 import { get } from '@services/storage'
+import { Wallet } from '../wallet'
 
-export default async function componentWillLoad() {
+export default async function componentWillLoad(this: Wallet) {
   try {
     const keystore = await get('WALLET[keystore]')
 

--- a/src/components/wallet/events/render.tsx
+++ b/src/components/wallet/events/render.tsx
@@ -2,8 +2,9 @@ import { h } from '@stencil/core'
 
 import loggedInContent from '../views/loggedInContent'
 import loggedOutContent from '../views/loggedOutContent'
+import { Wallet } from '../wallet'
 
-export default function () {
+export default function (this: Wallet) {
   const popup = this.promptContents ? (
     <div class="popup-scrim">
       <div class="popup">{this.promptContents}</div>

--- a/src/components/wallet/methods/copyAddress.ts
+++ b/src/components/wallet/methods/copyAddress.ts
@@ -1,6 +1,7 @@
 import copy from 'copy-to-clipboard'
+import { Wallet } from '../wallet'
 
-export default async function copyAddress() {
+export default async function copyAddress(this: Wallet) {
   copy(this.account.publicKey)
-  this.logger.instruction('Copying public key ' + this.account.publicKey)
+  this.logger.instruction('Copying public key ', this.account.publicKey)
 }

--- a/src/components/wallet/methods/copySecret.ts
+++ b/src/components/wallet/methods/copySecret.ts
@@ -3,8 +3,9 @@ import copy from 'copy-to-clipboard'
 import { handleError } from '@services/error'
 import { stretchPincode } from '@services/argon2'
 import { decrypt } from '@services/tweetnacl'
+import { Wallet } from '../wallet'
 
-export default async function copySecret() {
+export default async function copySecret(this: Wallet) {
   try {
     const pincode = await this.setPrompt({
       message: 'Enter your account pincode',

--- a/src/components/wallet/methods/createAccount.ts
+++ b/src/components/wallet/methods/createAccount.ts
@@ -5,8 +5,9 @@ import { set } from '@services/storage'
 import { handleError } from '@services/error'
 import { stretchPincode } from '@services/argon2'
 import { encrypt } from '@services/tweetnacl'
+import { Wallet } from '../wallet'
 
-export default async function createAccount() {
+export default async function createAccount(this: Wallet) {
   try {
     const pincode_1 = await this.setPrompt({
       message: 'Enter an account pincode',

--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -9,10 +9,11 @@ import {
 import { handleError } from '@services/error'
 import { stretchPincode } from '@services/argon2'
 import { decrypt } from '@services/tweetnacl'
+import { Wallet } from '../wallet'
 
-export default async function depositAsset() {
+export default async function depositAsset(this: Wallet) {
   try {
-    let currency = await this.setPrompt({
+    let currency: any = await this.setPrompt({
       message: "Select the currency you'd like to deposit",
       options: this.toml.CURRENCIES,
     })

--- a/src/components/wallet/methods/loadAccount.ts
+++ b/src/components/wallet/methods/loadAccount.ts
@@ -5,8 +5,9 @@ import { set } from '@services/storage'
 import { handleError } from '@services/error'
 import { stretchPincode } from '@services/argon2'
 import { encrypt } from '@services/tweetnacl'
+import { Wallet } from '../wallet'
 
-export default async function createAccount() {
+export default async function createAccount(this: Wallet) {
   try {
     const secret = await this.setPrompt({
       message: 'Enter your Stellar secret key',

--- a/src/components/wallet/methods/makePayment.ts
+++ b/src/components/wallet/methods/makePayment.ts
@@ -11,8 +11,10 @@ import { has as loHas } from 'lodash-es'
 import { handleError } from '@services/error'
 import { stretchPincode } from '@services/argon2'
 import { decrypt } from '@services/tweetnacl'
+import { Wallet } from '../wallet'
 
 export default async function makePayment(
+  this: Wallet,
   destination?: string,
   assetCode?: string,
   issuer?: string

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -14,8 +14,10 @@ import { handleError } from '@services/error'
 import { stretchPincode } from '@services/argon2'
 import { decrypt } from '@services/tweetnacl'
 import TransactionSummary from '../views/transactionSummary'
+import { Wallet } from '../wallet'
 
 export default async function makeRegulatedPayment(
+  this: Wallet,
   destination?: string,
   assetCode?: string,
   issuer?: string

--- a/src/components/wallet/methods/popup.tsx
+++ b/src/components/wallet/methods/popup.tsx
@@ -1,11 +1,12 @@
 import { h } from '@stencil/core'
+import { Wallet } from '../wallet'
 
 export interface PopupContents {
   contents: HTMLElement
   confirmLabel?: string
   cancelLabel?: string
 }
-const popup = async function (popup: PopupContents) {
+const popup = async function (this: Wallet, popup: PopupContents) {
   try {
     await new Promise((res, rej) => {
       const cancelButton = popup.cancelLabel ? (

--- a/src/components/wallet/methods/setPrompt.ts
+++ b/src/components/wallet/methods/setPrompt.ts
@@ -1,8 +1,8 @@
 interface setPrompt {
   message: string
-  placeholder: string
-  type: string
-  options: Array<any>
+  placeholder?: string
+  type?: string
+  options?: Array<any>
 }
 
 export default function setPrompt({

--- a/src/components/wallet/methods/signOut.ts
+++ b/src/components/wallet/methods/signOut.ts
@@ -1,7 +1,8 @@
 import { remove } from '@services/storage'
 import { handleError } from '@services/error'
+import { Wallet } from '../wallet'
 
-export default async function signOut() {
+export default async function signOut(this: Wallet) {
   try {
     const confirmNuke = await this.setPrompt({
       message: 'Are you sure? This will nuke your account',

--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -10,8 +10,10 @@ import {
 import { handleError } from '@services/error'
 import { stretchPincode } from '@services/argon2'
 import { decrypt } from '@services/tweetnacl'
+import { Wallet } from '../wallet'
 
 export default async function trustAsset(
+  this: Wallet,
   asset?: string,
   issuer?: string,
   pincode_stretched?: Uint8Array

--- a/src/components/wallet/methods/updateAccount.ts
+++ b/src/components/wallet/methods/updateAccount.ts
@@ -4,8 +4,9 @@ import {
 } from 'lodash-es'
 
 import { handleError } from '@services/error'
+import { Wallet } from '../wallet'
 
-export default async function updateAccount() {
+export default async function updateAccount(this: Wallet) {
   try {
     this.error = null
     this.loading = { ...this.loading, update: true }

--- a/src/components/wallet/methods/withdrawAsset.ts
+++ b/src/components/wallet/methods/withdrawAsset.ts
@@ -20,10 +20,11 @@ import {
 import { handleError } from '@services/error'
 import { stretchPincode } from '@services/argon2'
 import { decrypt } from '@services/tweetnacl'
+import { Wallet } from '../wallet'
 
-export default async function withdrawAsset() {
+export default async function withdrawAsset(this: Wallet) {
   try {
-    let currency = await this.setPrompt({
+    let currency: any = await this.setPrompt({
       message: "Select the currency you'd like to withdraw",
       options: this.toml.CURRENCIES,
     })
@@ -51,6 +52,7 @@ export default async function withdrawAsset() {
     })
 
     if (hasCurrency === -1)
+      //@ts-ignore
       await this.trustAsset(currency[0], currency[1], pincode)
 
     const info = await axios

--- a/src/components/wallet/readme.md
+++ b/src/components/wallet/readme.md
@@ -9,7 +9,7 @@
 | ------------ | --------- | ----------- | -------- | --------------------------------------------------- |
 | `homeDomain` | --        |             | `String` | `'testanchor.stellar.org'`                          |
 | `server`     | --        |             | `Server` | `new Server('https://horizon-testnet.stellar.org')` |
-| `toml`       | --        |             | `Object` | `undefined`                                         |
+| `toml`       | `toml`    |             | `any`    | `undefined`                                         |
 
 
 ## Dependencies

--- a/src/components/wallet/readme.md
+++ b/src/components/wallet/readme.md
@@ -5,11 +5,11 @@
 
 ## Properties
 
-| Property     | Attribute | Description | Type     | Default                                             |
-| ------------ | --------- | ----------- | -------- | --------------------------------------------------- |
-| `homeDomain` | --        |             | `String` | `'testanchor.stellar.org'`                          |
-| `server`     | --        |             | `Server` | `new Server('https://horizon-testnet.stellar.org')` |
-| `toml`       | `toml`    |             | `any`    | `undefined`                                         |
+| Property     | Attribute     | Description | Type     | Default                                             |
+| ------------ | ------------- | ----------- | -------- | --------------------------------------------------- |
+| `homeDomain` | `home-domain` |             | `string` | `'testanchor.stellar.org'`                          |
+| `server`     | --            |             | `Server` | `new Server('https://horizon-testnet.stellar.org')` |
+| `toml`       | `toml`        |             | `any`    | `undefined`                                         |
 
 
 ## Dependencies

--- a/src/components/wallet/views/balanceDisplay.tsx
+++ b/src/components/wallet/views/balanceDisplay.tsx
@@ -1,5 +1,6 @@
 import { h } from '@stencil/core'
 import { has as loHas } from 'lodash-es'
+import { Wallet } from '../wallet'
 
 interface Balance {
   balance: string
@@ -9,7 +10,7 @@ interface Balance {
   asset_issuer: string
 }
 
-export default function balanceDisplay() {
+export default function balanceDisplay(this: Wallet) {
   const balanceRow = (balance: Balance) => {
     const isRegulated =
       !balance.is_authorized && balance.asset_type !== 'native'

--- a/src/components/wallet/views/loggedInContent.tsx
+++ b/src/components/wallet/views/loggedInContent.tsx
@@ -2,8 +2,9 @@ import { h } from '@stencil/core'
 import { has as loHas } from 'lodash-es'
 
 import balanceDisplay from './balanceDisplay'
+import { Wallet } from '../wallet'
 
-export default function loggedInContent() {
+export default function loggedInContent(this: Wallet) {
   return [
     <div class="account-key">
       <p>{this.account.publicKey}</p>

--- a/src/components/wallet/views/loggedOutContent.tsx
+++ b/src/components/wallet/views/loggedOutContent.tsx
@@ -1,6 +1,7 @@
 import { h } from '@stencil/core'
+import { Wallet } from '../wallet'
 
-export default function loggedOutContent() {
+export default function loggedOutContent(this: Wallet) {
   return [
     <button
       class={this.loading.create ? 'loading' : null}

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -51,7 +51,7 @@ export class Wallet {
 
   @Prop() server: Server = new Server('https://horizon-testnet.stellar.org')
   @Prop() homeDomain: String = 'testanchor.stellar.org'
-  @Prop() toml: Object // NEW
+  @Prop() toml: any // NEW
 
   // Component events
   componentWillLoad() {}

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -50,7 +50,7 @@ export class Wallet {
   @State() promptContents: string = null
 
   @Prop() server: Server = new Server('https://horizon-testnet.stellar.org')
-  @Prop() homeDomain: String = 'testanchor.stellar.org'
+  @Prop() homeDomain: string = 'testanchor.stellar.org'
   @Prop() toml: any // NEW
 
   // Component events


### PR DESCRIPTION
Typescript offers a [fake this](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#specifying-the-type-of-this-for-functions) functionality where you can tell a function what the type of `this` will be.  In our wallet methods and views, `this` refers to the Wallet component.  Adding the Wallet type to `this` in all these methods means we will get auto-complete and typechecking rather than dealing with opaque objects.

Before

<img width="461" alt="Screenshot 2020-07-09 at 9 01 31 PM" src="https://user-images.githubusercontent.com/161135/87115202-6b6c6380-c227-11ea-9631-72f87dda1d82.png">

After
<img width="618" alt="Screenshot 2020-07-09 at 9 01 36 PM" src="https://user-images.githubusercontent.com/161135/87115210-745d3500-c227-11ea-9740-9ac118022d25.png">
