### PR TITLE
Introductory PR with a majority of the deposit logging added

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16,8 +16,8 @@ export namespace Components {
     interface LogView {
         "error": (title: string, body?: string) => Promise<void>;
         "instruction": (title: string, body?: string) => Promise<void>;
-        "request": (url: string, body?: string) => Promise<void>;
-        "response": (url: string, body?: string) => Promise<void>;
+        "request": (url: string, body?: string | object) => Promise<void>;
+        "response": (url: string, body?: string | object) => Promise<void>;
     }
     interface StellarLoader {
         "interval": any;

--- a/src/components/logview/logview.tsx
+++ b/src/components/logview/logview.tsx
@@ -10,14 +10,14 @@ interface LogData {
   type: LogDataType
   url?: string
   title?: string
-  body?: string
+  body?: string | object
 }
 
 export interface ILogger {
-  request: (url: string, body?: string) => Promise<void> | void
-  response: (url: string, body?: string) => Promise<void> | void
+  request: (url: string, body?: string | object) => Promise<void> | void
+  response: (url: string, body?: string | object) => Promise<void> | void
   instruction: (title: string, body?: string) => Promise<void> | void
-  error: (title: string, body?: string) => Promise<void> | void
+  error: (title: string, body?: string | object) => Promise<void> | void
 }
 
 @Component({
@@ -34,14 +34,14 @@ export class LogView {
 
   // Log an outgoing network request with a url and optional body
   @Method()
-  async request(url: string, body?: string) {
+  async request(url: string, body?: string | object) {
     console.log('Request', url, body)
     this.append({ type: LogDataType.Request, url, body })
   }
 
   // Log the incoming response from a request
   @Method()
-  async response(url: string, body?: string) {
+  async response(url: string, body?: string | object) {
     console.log('Response', url, body)
     this.append({ type: LogDataType.Response, url, body })
   }

--- a/src/components/logview/readme.md
+++ b/src/components/logview/readme.md
@@ -27,7 +27,7 @@ Type: `Promise<void>`
 
 
 
-### `request(url: string, body?: string) => Promise<void>`
+### `request(url: string, body?: string | object) => Promise<void>`
 
 
 
@@ -37,7 +37,7 @@ Type: `Promise<void>`
 
 
 
-### `response(url: string, body?: string) => Promise<void>`
+### `response(url: string, body?: string | object) => Promise<void>`
 
 
 

--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -80,14 +80,12 @@ export default async function depositAsset(
     this.logger.instruction(
       'Start the SEP-0010 flow to authenticate the wallet’s Stellar account'
     )
-    const params = { account: this.account.publicKey }
-    this.logger.request(this.toml.WEB_AUTH_ENDPOINT, params)
+    const authParams = { account: this.account.publicKey }
+    this.logger.request(this.toml.WEB_AUTH_ENDPOINT, authParams)
 
     const auth = await axios
       .get(`${toml.WEB_AUTH_ENDPOINT}`, {
-        params: {
-          account: this.account.publicKey,
-        },
+        params: authParams,
       })
       .then(async ({ data }) => {
         this.logger.response(this.toml.WEB_AUTH_ENDPOINT, data)
@@ -147,8 +145,8 @@ export default async function depositAsset(
       'To get the url for the interactive flow check the /transactions/deposit/interactive endpoint'
     )
     this.logger.request(
-      toml.TRANSFER_SERVER_SEP0024 + '/transactions/deposit/interactive',
-      'TODO: form data'
+      `${toml.TRANSFER_SERVER_SEP0024} /transactions/deposit/interactive`
+      /* TODO add form data object */
     )
 
     const interactive = await axios

--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -21,8 +21,19 @@ export default async function trustAsset(
   try {
     let instructions
 
-    if (asset && issuer) instructions = [asset, issuer]
-    else {
+    this.logger.instruction(
+      'We need to add a trustline to the asset to ensure the deposit will be expected'
+    )
+
+    if (asset && issuer) {
+      instructions = [asset, issuer]
+      this.logger.instruction(
+        'There is already a trustline on this account, no need to recreate it'
+      )
+    } else {
+      this.logger.instruction(
+        'There isn’t currently a trustline on this account so we need to add one'
+      )
       instructions = await this.setPrompt({ message: '{Asset} {Issuer}' })
       instructions = instructions.split(' ')
     }

--- a/src/components/wallet/methods/updateAccount.ts
+++ b/src/components/wallet/methods/updateAccount.ts
@@ -1,5 +1,6 @@
 import {
   omit as loOmit,
+  find as loFind,
   // map as loMap
 } from 'lodash-es'
 
@@ -10,12 +11,15 @@ export default async function updateAccount(this: Wallet) {
   try {
     this.error = null
     this.loading = { ...this.loading, update: true }
-
+    this.logger.instruction('Updating account...')
     await this.server
       .accounts()
       .accountId(this.account.publicKey)
       .call()
       .then((account) => {
+        const selfURL = loFind(account, 'self')
+        this.logger.request(selfURL.self.href)
+
         this.account = {
           ...this.account,
           state: loOmit(account, [
@@ -25,6 +29,7 @@ export default async function updateAccount(this: Wallet) {
             'paging_token',
           ]),
         }
+        this.logger.response(selfURL.self.href, account)
       })
       .finally(() => (this.loading = { ...this.loading, update: false }))
   } catch (err) {


### PR DESCRIPTION
### What it is
Initial commit of deposit logging as defined by https://github.com/stellar/stellar-demo-wallet/issues/15

### What got changed
- `depositAsset.ts` - lots of instructions, requests, and responses; I had difficulty including them in the `await` functionality so currently several of the request and response logging is "fake" i.e. it's not tied to actual promises
- `trustAsset.ts` - in order to add `trustline` logging
- `updateAccount.ts` - this may not be necessary as the `updateaccount` function seems to be run multiple times

### What to look for

- Typescript seemingly doesn't like objects in the second argument of the request and response logs, but logview.txt seems like it should allow both types
- Let me know if the "fake" logging is okay or if it should be tied to actual requests
- Currently some of the object parsing in the window is ridiculously long - I'm assuming the clever hide/show functionality for JSON objects that was in the old wallet needs to be transferred?
