### PR TITLE
Add collapsible JSON in logview

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -13,6 +13,9 @@ export namespace Components {
         "hideText": string;
         "showText": string;
     }
+    interface JsonViewer {
+        "data": any;
+    }
     interface LogView {
         "error": (title: string, body?: string) => Promise<void>;
         "instruction": (title: string, body?: string) => Promise<void>;
@@ -38,6 +41,12 @@ declare global {
     var HTMLCollapsibleContainerElement: {
         prototype: HTMLCollapsibleContainerElement;
         new (): HTMLCollapsibleContainerElement;
+    };
+    interface HTMLJsonViewerElement extends Components.JsonViewer, HTMLStencilElement {
+    }
+    var HTMLJsonViewerElement: {
+        prototype: HTMLJsonViewerElement;
+        new (): HTMLJsonViewerElement;
     };
     interface HTMLLogViewElement extends Components.LogView, HTMLStencilElement {
     }
@@ -65,6 +74,7 @@ declare global {
     };
     interface HTMLElementTagNameMap {
         "collapsible-container": HTMLCollapsibleContainerElement;
+        "json-viewer": HTMLJsonViewerElement;
         "log-view": HTMLLogViewElement;
         "stellar-loader": HTMLStellarLoaderElement;
         "stellar-prompt": HTMLStellarPromptElement;
@@ -75,6 +85,9 @@ declare namespace LocalJSX {
     interface CollapsibleContainer {
         "hideText"?: string;
         "showText"?: string;
+    }
+    interface JsonViewer {
+        "data"?: any;
     }
     interface LogView {
     }
@@ -92,6 +105,7 @@ declare namespace LocalJSX {
     }
     interface IntrinsicElements {
         "collapsible-container": CollapsibleContainer;
+        "json-viewer": JsonViewer;
         "log-view": LogView;
         "stellar-loader": StellarLoader;
         "stellar-prompt": StellarPrompt;
@@ -103,6 +117,7 @@ declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
             "collapsible-container": LocalJSX.CollapsibleContainer & JSXBase.HTMLAttributes<HTMLCollapsibleContainerElement>;
+            "json-viewer": LocalJSX.JsonViewer & JSXBase.HTMLAttributes<HTMLJsonViewerElement>;
             "log-view": LocalJSX.LogView & JSXBase.HTMLAttributes<HTMLLogViewElement>;
             "stellar-loader": LocalJSX.StellarLoader & JSXBase.HTMLAttributes<HTMLStellarLoaderElement>;
             "stellar-prompt": LocalJSX.StellarPrompt & JSXBase.HTMLAttributes<HTMLStellarPromptElement>;

--- a/src/components/jsonviewer/jsonviewer.scss
+++ b/src/components/jsonviewer/jsonviewer.scss
@@ -1,6 +1,7 @@
 :host {
   font-family: monospace;
 }
+
 .indent {
   margin-left: 16px;
 }

--- a/src/components/jsonviewer/jsonviewer.scss
+++ b/src/components/jsonviewer/jsonviewer.scss
@@ -1,0 +1,14 @@
+:host {
+  font-family: monospace;
+}
+.indent {
+  margin-left: 16px;
+}
+
+details {
+  display: inline-block;
+}
+
+summary {
+  font-weight: bold;
+}

--- a/src/components/jsonviewer/jsonviewer.tsx
+++ b/src/components/jsonviewer/jsonviewer.tsx
@@ -1,0 +1,43 @@
+import { Component, h, Prop } from '@stencil/core'
+
+@Component({
+  tag: 'json-viewer',
+  styleUrl: 'jsonviewer.scss',
+  shadow: true,
+})
+export class JSONViewer {
+  @Prop() data: any
+
+  render() {
+    return (
+      <div>
+        {'{'}
+        <div class="indent">
+          {Object.keys(this.data).map((key) => {
+            const val = this.data[key]
+            let display = ''
+            switch (typeof val) {
+              case 'object':
+                display = (
+                  <details>
+                    <summary>
+                      {key}: {Object.keys(val).length} values
+                    </summary>
+                    <json-viewer data={val}></json-viewer>
+                  </details>
+                )
+                break
+              case 'function':
+                display = `${key}: Function`
+                break
+              default:
+                display = `${key}: ${val}`
+            }
+            return <div>{display}</div>
+          })}
+        </div>
+        {'}'}
+      </div>
+    )
+  }
+}

--- a/src/components/jsonviewer/readme.md
+++ b/src/components/jsonviewer/readme.md
@@ -1,0 +1,36 @@
+# json-viewer
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property | Attribute | Description | Type  | Default     |
+| -------- | --------- | ----------- | ----- | ----------- |
+| `data`   | `data`    |             | `any` | `undefined` |
+
+
+## Dependencies
+
+### Used by
+
+ - [json-viewer](.)
+ - [log-view](../logview)
+
+### Depends on
+
+- [json-viewer](.)
+
+### Graph
+```mermaid
+graph TD;
+  json-viewer --> json-viewer
+  log-view --> json-viewer
+  style json-viewer fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/logview/logview.scss
+++ b/src/components/logview/logview.scss
@@ -64,6 +64,7 @@ $error-icon: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTVweCIgaGVpZ2h0PSIxN
   .body {
     background-color: #4d556d;
     white-space: pre;
+    overflow-x: scroll;
   }
 }
 

--- a/src/components/logview/logview.tsx
+++ b/src/components/logview/logview.tsx
@@ -8,7 +8,6 @@ enum LogDataType {
 }
 interface LogData {
   type: LogDataType
-  url?: string
   title?: string
   body?: string | object
 }
@@ -36,14 +35,14 @@ export class LogView {
   @Method()
   async request(url: string, body?: string | object) {
     console.log('Request', url, body)
-    this.append({ type: LogDataType.Request, url, body })
+    this.append({ type: LogDataType.Request, title: url, body })
   }
 
   // Log the incoming response from a request
   @Method()
   async response(url: string, body?: string | object) {
     console.log('Response', url, body)
-    this.append({ type: LogDataType.Response, url, body })
+    this.append({ type: LogDataType.Response, title: url, body })
   }
 
   // Log an informational statement with a title and optional body
@@ -65,50 +64,24 @@ export class LogView {
   }
 
   transformToElement(data: LogData) {
-    switch (data.type) {
-      case LogDataType.Instruction:
-        return (
-          <div class="instruction entry">
-            <div class="title">{data.title}</div>
-            {data.body ? <div class="body">{data.body}</div> : null}
-          </div>
-        )
-
-      case LogDataType.Error:
-        return (
-          <div class="error entry">
-            <div class="title">{data.title}</div>
-            {data.body ? <div class="body">{data.body}</div> : null}
-          </div>
-        )
-
-      case LogDataType.Request:
-        const requestBody =
-          typeof data.body == 'string'
-            ? data.body
-            : JSON.stringify(data.body, null, 2)
-        return (
-          <div class="request entry">
-            <div class="title">{data.url}</div>
-            <div class="body">{requestBody}</div>
-          </div>
-        )
-
-      case LogDataType.Response:
-        const responseBody =
-          typeof data.body == 'string'
-            ? data.body
-            : JSON.stringify(data.body, null, 2)
-        return (
-          <div class="response entry">
-            <div class="title">{data.url}</div>
-            <div class="body">{responseBody}</div>
-          </div>
-        )
-
-      default:
-        return null
-    }
+    const className = {
+      [LogDataType.Instruction]: 'instruction',
+      [LogDataType.Error]: 'error',
+      [LogDataType.Request]: 'request',
+      [LogDataType.Response]: 'response',
+    }[data.type]
+    const body =
+      typeof data.body === 'object' ? (
+        <json-viewer data={data.body}></json-viewer>
+      ) : (
+        data.body
+      )
+    return (
+      <div class={`entry ${className}`}>
+        <div class="title">{data.title}</div>
+        {body ? <div class="body">{body}</div> : null}
+      </div>
+    )
   }
 
   render() {

--- a/src/components/logview/readme.md
+++ b/src/components/logview/readme.md
@@ -48,6 +48,20 @@ Type: `Promise<void>`
 
 
 
+## Dependencies
+
+### Depends on
+
+- [json-viewer](../jsonviewer)
+
+### Graph
+```mermaid
+graph TD;
+  log-view --> json-viewer
+  json-viewer --> json-viewer
+  style log-view fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
The logviews were huge and noisy since we just serialized the full json objects.  This PR adds a json-viewer webcomponent to allow us to show only the top level of an object and allow you to expand subproperties to view more detail.

The code in components.d.ts is auto-generated you don' t need to review that.


![Screenshot 2020-07-16 at 11 25 33 AM](https://user-images.githubusercontent.com/161135/87708124-15cc1580-c757-11ea-9ad7-675aaeb26dea.png)
