### PR TITLE
Remove unpkg css file

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,6 @@
     />
     <title>Stellar Wallet</title>
 
-    <link rel="stylesheet" href="https://unpkg.com/reset-css/reset.css" />
     <style>
       html,
       body {


### PR DESCRIPTION
We had this css reset file that we don't seem to actually depend on.  It adds an external blocking request to slow the page down, and some warnings in the console.  If we find some place it was actually needed we can add the single css declaration to our own css

unpkg is a CDN for hosting npm packages you can include via an html script tag.