### PR TITLE
Clean up the trust asset flow

### DIFF
--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -1,5 +1,4 @@
 import {
-  Account,
   TransactionBuilder,
   BASE_FEE,
   Networks,

--- a/src/components/wallet/methods/withdrawAsset.ts
+++ b/src/components/wallet/methods/withdrawAsset.ts
@@ -49,16 +49,6 @@ export default async function withdrawAsset(
       pincode_stretched
     )
 
-    const balances = loGet(this.account, 'state.balances')
-    const hasCurrency = loFindIndex(balances, {
-      asset_code: assetCode,
-      asset_issuer: assetIssuer,
-    })
-
-    if (hasCurrency === -1)
-      //@ts-ignore
-      await this.trustAsset(assetCode, assetIssuer, pincode)
-
     const server = this.server as Server
     const issuerAccount = await server.loadAccount(assetIssuer)
     const homeDomain: string = (issuerAccount as any).home_domain

--- a/src/components/wallet/methods/withdrawAsset.ts
+++ b/src/components/wallet/methods/withdrawAsset.ts
@@ -49,6 +49,16 @@ export default async function withdrawAsset(
       pincode_stretched
     )
 
+    const balances = loGet(this.account, 'state.balances')
+    const hasCurrency = loFindIndex(balances, {
+      asset_code: assetCode,
+      asset_issuer: assetIssuer,
+    })
+
+    if (hasCurrency === -1)
+      //@ts-ignore
+      await this.trustAsset(assetCode, assetIssuer, pincode)
+
     const server = this.server as Server
     const issuerAccount = await server.loadAccount(assetIssuer)
     const homeDomain: string = (issuerAccount as any).home_domain


### PR DESCRIPTION
Use explicit variable names for asset_code and issuer, vs instructions[0][1]
Break out nested promises into async
Add proper logger calls