### PR TITLE
Add multiple inputs to Prompt component

### DIFF
--- a/src/components/prompt/prompt.tsx
+++ b/src/components/prompt/prompt.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, h, State } from '@stencil/core'
+import { Component, Prop, h } from '@stencil/core'
 import { PromptInput } from './promptInput'
 
 export interface Prompter {
@@ -20,8 +20,6 @@ export class Prompt {
 
   @Prop({ mutable: true }) prompter: Prompter
 
-  @State() private inputs: Array<PromptInput>
-
   cancel() {
     this.prompter = {
       ...this.prompter,
@@ -35,7 +33,9 @@ export class Prompt {
       ...this.prompter,
       show: false,
     }
-    this.prompter.resolve(this.inputs)
+    console.log('resolving this.prompter.inputs')
+    console.log(typeof this.prompter.inputs)
+    this.prompter.resolve(this.prompter.inputs)
   }
 
   render() {

--- a/src/components/prompt/prompt.tsx
+++ b/src/components/prompt/prompt.tsx
@@ -1,12 +1,10 @@
-import { Component, Prop, Element, Watch, h, State } from '@stencil/core'
-import { defer as loDefer } from 'lodash-es'
+import { Component, Prop, h, State } from '@stencil/core'
+import { PromptInput } from './promptInput'
 
 export interface Prompter {
   show: boolean
-  type?: string
   message?: string
-  placeholder?: string
-  options?: Array<any>
+  inputs?: Array<PromptInput>
   resolve?: Function
   reject?: Function
 }
@@ -17,32 +15,12 @@ export interface Prompter {
   shadow: true,
 })
 export class Prompt {
-  @Element() private element: HTMLElement
+  // Unused currently, but it may be helpful for someone in the future
+  // @Element() private element: HTMLElement
 
   @Prop({ mutable: true }) prompter: Prompter
 
-  @State() private input: string
-
-  @Watch('prompter')
-  watchHandler(newValue: Prompter, oldValue: Prompter) {
-    if (newValue.show === oldValue.show) return
-
-    if (newValue.show) {
-      this.input = null
-
-      if (newValue.options)
-        this.input =
-          this.input ||
-          `${newValue.options[0].code}:${newValue.options[0].issuer}`
-      else loDefer(() => this.element.shadowRoot.querySelector('input').focus())
-    } else {
-      this.prompter.message = null
-      this.prompter.placeholder = null
-      this.prompter.options = null
-    }
-  }
-
-  componentDidLoad() {}
+  @State() private inputs: Array<PromptInput>
 
   cancel() {
     this.prompter = {
@@ -57,11 +35,7 @@ export class Prompt {
       ...this.prompter,
       show: false,
     }
-    this.prompter.resolve(this.input)
-  }
-
-  update(e: any) {
-    this.input = e.target.value.toUpperCase()
+    this.prompter.resolve(this.inputs)
   }
 
   render() {
@@ -73,32 +47,33 @@ export class Prompt {
         <div class="prompt">
           {this.prompter.message ? <p>{this.prompter.message}</p> : null}
 
-          {this.prompter.options ? (
-            <div class="select-wrapper">
-              <select onInput={(e) => this.update(e)}>
-                {this.prompter.options.map((option) => (
-                  <option
-                    value={`${option.code}:${option.issuer}`}
-                    selected={this.input === `${option.code}:${option.issuer}`}
-                  >
-                    {option.code}
-                  </option>
-                ))}
-              </select>
-            </div>
-          ) : (
-            <input
-              type={this.prompter.type}
-              placeholder={this.prompter.placeholder}
-              value={this.input}
-              onInput={(e) => this.update(e)}
-              style={
-                this.prompter.type === 'password'
-                  ? { 'font-size': '18px' }
-                  : null
-              }
-            ></input>
-          )}
+          <div class="inputs-wrapper">
+            {this.prompter.inputs.map((i) =>
+              i.type !== 'select' ? (
+                <input
+                  type={i.type}
+                  placeholder={i.placeholder}
+                  value={i.value}
+                  onInput={(e) => i.update(e)}
+                ></input>
+              ) : (
+                <select
+                  onInput={(e) => {
+                    i.update(e)
+                  }}
+                >
+                  {i.options.map((option) => {
+                    ;<option
+                      value={option.value}
+                      selected={i.value === option.value}
+                    >
+                      {option.showValue}
+                    </option>
+                  })}
+                </select>
+              )
+            )}
+          </div>
 
           <div class="actions">
             <button class="cancel" type="button" onClick={() => this.cancel()}>

--- a/src/components/prompt/promptInput.tsx
+++ b/src/components/prompt/promptInput.tsx
@@ -1,0 +1,20 @@
+// PromptInput may be a '<select></select>` tag
+// So this class is for the '<option></option>' tags
+export class PromptSelectInputOption {
+  value: any
+  showValue: string
+  selected: boolean
+}
+
+export class PromptInput {
+  constructor(
+    public placeholder: string,
+    public type: string = 'text',
+    public value?: string,
+    public options?: Array<PromptSelectInputOption>
+  ) {}
+
+  update(e: any) {
+    this.value = e.target.value
+  }
+}

--- a/src/components/prompt/promptInput.tsx
+++ b/src/components/prompt/promptInput.tsx
@@ -8,7 +8,7 @@ export class PromptSelectInputOption {
 
 export class PromptInput {
   constructor(
-    public placeholder: string,
+    public placeholder?: string,
     public type: string = 'text',
     public value?: string,
     public options?: Array<PromptSelectInputOption>

--- a/src/components/wallet/methods/loadAccount.ts
+++ b/src/components/wallet/methods/loadAccount.ts
@@ -7,9 +7,10 @@ import { Wallet } from '../wallet'
 
 export default async function createAccount(this: Wallet) {
   try {
-    const secret = await this.setPrompt({
+    let inputs = await this.setPrompt({
       message: 'Enter your Stellar secret key',
     })
+    const secret = inputs[0].value
 
     let keypair
     try {

--- a/src/components/wallet/methods/makePayment.ts
+++ b/src/components/wallet/methods/makePayment.ts
@@ -18,22 +18,27 @@ export default async function makePayment(
   assetCode?: string,
   issuer?: string
 ) {
+  let inputs
   try {
-    if (!destination)
-      destination = await this.setPrompt({ message: 'Destination address' })
+    if (!destination) {
+      inputs = await this.setPrompt({ message: 'Destination address' })
+      destination = inputs[0].value
+    }
 
     if (!assetCode || (!issuer && assetCode !== 'XLM')) {
-      const assetAndIssuer = await this.setPrompt({
+      inputs = await this.setPrompt({
         message: '{Asset} {Issuer} (leave empty for XLM)',
       })
+      const assetAndIssuer: string = inputs[0].value
 
       if (assetAndIssuer === '') assetCode = 'XLM'
       else [assetCode, issuer] = assetAndIssuer.split(' ')
     }
 
-    const amount = await this.setPrompt({
+    inputs = await this.setPrompt({
       message: `How much ${assetCode} to pay?`,
     })
+    const amount = inputs[0].value
 
     const keypair = Keypair.fromSecret(this.account.secretKey)
 

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -21,23 +21,28 @@ export default async function makeRegulatedPayment(
   assetCode?: string,
   issuer?: string
 ) {
+  let inputs
   try {
     const server = this.server as Server
-    if (!destination)
-      destination = await this.setPrompt({ message: 'Destination address' })
+    if (!destination) {
+      inputs = await this.setPrompt({ message: 'Destination address' })
+      destination = inputs[0].value
+    }
 
     if (!assetCode || (!issuer && assetCode !== 'XLM')) {
-      const assetAndIssuer = await this.setPrompt({
+      inputs = await this.setPrompt({
         message: '{Asset} {Issuer} (leave empty for XLM)',
       })
+      const assetAndIssuer: string = inputs[0].value
 
       if (assetAndIssuer === '') assetCode = 'XLM'
       else [assetCode, issuer] = assetAndIssuer.split(' ')
     }
 
-    const amount = await this.setPrompt({
+    inputs = await this.setPrompt({
       message: `How much ${assetCode} to pay?`,
     })
+    const amount: string = inputs[0].value
 
     const loadingKey = `sendRegulated:${assetCode}:${issuer}`
     this.loading = { ...this.loading, [loadingKey]: true }

--- a/src/components/wallet/methods/setPrompt.ts
+++ b/src/components/wallet/methods/setPrompt.ts
@@ -10,7 +10,7 @@ export default function setPrompt({
   inputs,
 }: setPrompt): Promise<string> {
   if (!inputs) {
-    inputs = [new PromptInput('text')]
+    inputs = [new PromptInput()]
   }
   this.prompter = {
     ...this.prompter,

--- a/src/components/wallet/methods/setPrompt.ts
+++ b/src/components/wallet/methods/setPrompt.ts
@@ -1,23 +1,22 @@
+import { PromptInput } from '../../prompt/promptInput'
+
 interface setPrompt {
   message: string
-  placeholder?: string
-  type?: string
-  options?: Array<any>
+  inputs?: Array<any>
 }
 
 export default function setPrompt({
   message,
-  placeholder,
-  type = 'text',
-  options,
+  inputs,
 }: setPrompt): Promise<string> {
+  if (!inputs) {
+    inputs = [new PromptInput('text')]
+  }
   this.prompter = {
     ...this.prompter,
     show: true,
     message,
-    placeholder,
-    type,
-    options,
+    inputs,
   }
 
   return new Promise((resolve, reject) => {

--- a/src/components/wallet/methods/setPrompt.ts
+++ b/src/components/wallet/methods/setPrompt.ts
@@ -8,7 +8,7 @@ interface setPrompt {
 export default function setPrompt({
   message,
   inputs,
-}: setPrompt): Promise<string> {
+}: setPrompt): Promise<Array<PromptInput>> {
   if (!inputs) {
     inputs = [new PromptInput()]
   }

--- a/src/components/wallet/methods/signOut.ts
+++ b/src/components/wallet/methods/signOut.ts
@@ -1,12 +1,13 @@
 import { remove } from '@services/storage'
 import { handleError } from '@services/error'
 import { Wallet } from '../wallet'
+import { PromptInput } from '../../prompt/promptInput'
 
 export default async function signOut(this: Wallet) {
   try {
     const confirmNuke = await this.setPrompt({
       message: 'Are you sure? This will nuke your account',
-      placeholder: 'Enter NUKE to confirm',
+      inputs: [new PromptInput('Enter NUKE to confirm')],
     })
 
     if (!confirm || !/nuke/gi.test(confirmNuke)) throw 'Cannot sign out'

--- a/src/components/wallet/methods/signOut.ts
+++ b/src/components/wallet/methods/signOut.ts
@@ -5,10 +5,11 @@ import { PromptInput } from '../../prompt/promptInput'
 
 export default async function signOut(this: Wallet) {
   try {
-    const confirmNuke = await this.setPrompt({
+    const inputs = await this.setPrompt({
       message: 'Are you sure? This will nuke your account',
       inputs: [new PromptInput('Enter NUKE to confirm')],
     })
+    const confirmNuke = inputs[0].value
 
     if (!confirm || !/nuke/gi.test(confirmNuke)) throw 'Cannot sign out'
 

--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -19,10 +19,11 @@ export default async function trustAsset(
   this.error = null
   console.log(this.loading)
   const finish = () => (this.loading = { ...this.loading, trust: false })
+  let inputs
   try {
     if (!asset || !issuer) {
-      let instructions = await this.setPrompt({ message: '{Asset} {Issuer}' })
-      ;[asset, issuer] = instructions.split(' ')
+      inputs = await this.setPrompt({ message: '{Asset} {Issuer}' })
+      ;[asset, issuer] = inputs[0].value.split(' ')
     }
 
     const keypair = Keypair.fromSecret(this.account.secretKey)

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -59,7 +59,7 @@ interface Loading {
 })
 export class Wallet {
   @State() account: StellarAccount
-  @State() prompter: Prompter = { show: false }
+  @State() prompter: Prompter = { show: false, inputs: [] }
   @State() loading: Loading = {}
   @State() error: any
   @State() promptContents: string = null


### PR DESCRIPTION
Doesn't change any functionality from the user's perspective. UX is unchanged.

The difference under the hood is that we can now ask for multi-input prompts. We'll use this at first to ask for the asset code, issuer, or homedomain in separate input fields.