### PR TITLE
Fix tomlURL bug

### DIFF
--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -24,7 +24,6 @@ export default async function depositAsset(
     this.logger.instruction(
       `Found home_domain '${homeDomain}' as issuer's domain, fetching the TOML file to find the transfer server`
     )
-    debugger
     const tomlURL = new URL(
       homeDomain.includes('https://') ? homeDomain : 'https://' + homeDomain
     )

--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -24,7 +24,10 @@ export default async function depositAsset(
     this.logger.instruction(
       `Found home_domain '${homeDomain}' as issuer's domain, fetching the TOML file to find the transfer server`
     )
-    const tomlURL = new URL(homeDomain)
+    debugger
+    const tomlURL = new URL(
+      homeDomain.includes('https://') ? homeDomain : 'https://' + homeDomain
+    )
     tomlURL.pathname = '/.well-known/stellar.toml'
     this.logger.request(tomlURL.toString())
     const tomlText = await fetch(tomlURL.toString()).then((r) => r.text())

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -63,7 +63,9 @@ export default async function makeRegulatedPayment(
     this.logger.instruction(
       `Found home_domain '${homeDomain}' as issuer's domain, fetching the TOML file to find the approval server`
     )
-    const tomlURL = new URL(homeDomain)
+    const tomlURL = new URL(
+      homeDomain.includes('https://') ? homeDomain : 'https://' + homeDomain
+    )
     tomlURL.pathname = '/.well-known/stellar.toml'
     this.logger.request(tomlURL.toString())
     const tomlText = await fetch(tomlURL.toString()).then((r) => r.text())

--- a/src/components/wallet/methods/withdrawAsset.ts
+++ b/src/components/wallet/methods/withdrawAsset.ts
@@ -56,7 +56,9 @@ export default async function withdrawAsset(
     this.logger.instruction(
       `Found home_domain '${homeDomain}' as issuer's domain, fetching the TOML file to find the approval server`
     )
-    const tomlURL = new URL(homeDomain)
+    const tomlURL = new URL(
+      homeDomain.includes('https://') ? homeDomain : 'https://' + homeDomain
+    )
     tomlURL.pathname = '/.well-known/stellar.toml'
     this.logger.request(tomlURL.toString())
     const tomlText = await fetch(tomlURL.toString()).then((r) => r.text())


### PR DESCRIPTION
- there was a case where the URL builder would fail if there wasnt a
`https://` attached to it

Signed-off-by: Lawrence Lawson <lawrence@stellar.org>