### PR TITLE
Add Support for Pubnet

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -32,6 +32,7 @@ export namespace Components {
     interface StellarWallet {
         "assets": Map<string, WalletAssetDetails>;
         "logger": ILogger;
+        "network_passphrase": string;
         "server": Server;
     }
 }
@@ -100,6 +101,7 @@ declare namespace LocalJSX {
     interface StellarWallet {
         "assets"?: Map<string, WalletAssetDetails>;
         "logger"?: ILogger;
+        "network_passphrase"?: string;
         "server"?: Server;
     }
     interface IntrinsicElements {

--- a/src/components/wallet/events/componentWillLoad.ts
+++ b/src/components/wallet/events/componentWillLoad.ts
@@ -1,7 +1,7 @@
 import { handleError } from '@services/error'
 import { get } from '@services/storage'
 import { Wallet } from '../wallet'
-import { Keypair } from 'stellar-sdk'
+import { Keypair, Networks, Server } from 'stellar-sdk'
 
 export default async function componentWillLoad(this: Wallet) {
   try {
@@ -17,6 +17,13 @@ async function loadAccountFromBrowser(wallet: Wallet) {
     query = Object.fromEntries(new URLSearchParams(location.search).entries())
   } catch {
     throw 'Unable to parse query string'
+  }
+  if (query.pubnet === 'true') {
+    wallet.network_passphrase = Networks.PUBLIC
+    wallet.server = new Server('https://horizon.stellar.org')
+  } else {
+    wallet.network_passphrase = Networks.TESTNET
+    wallet.server = new Server('https://horizon-testnet.stellar.org')
   }
   if (query.secretKey) {
     await loadAccountFromSecretKey(wallet, query.secretKey)

--- a/src/components/wallet/methods/claimAsset.ts
+++ b/src/components/wallet/methods/claimAsset.ts
@@ -2,7 +2,6 @@ import {
   Account,
   TransactionBuilder,
   BASE_FEE,
-  Networks,
   Operation,
   Keypair,
 } from 'stellar-sdk'
@@ -37,7 +36,7 @@ export default async function claimAsset(
     this.logger.instruction('Building claimClaimableBalance transaction')
     const transaction = new TransactionBuilder(account, {
       fee: BASE_FEE,
-      networkPassphrase: Networks.TESTNET,
+      networkPassphrase: this.network_passphrase,
     })
       .addOperation(
         Operation.claimClaimableBalance({

--- a/src/components/wallet/methods/createAccount.ts
+++ b/src/components/wallet/methods/createAccount.ts
@@ -25,6 +25,8 @@ export default async function createAccount(this: Wallet) {
     set('WALLET[keystore]', btoa(JSON.stringify(this.account)))
 
     await this.updateAccount()
+    // No need to check for this.network_passphrase === Networks.PUBLIC
+    // since this button is not displayed when that condition is true
     history.replaceState(null, '', `?secretKey=${this.account.secretKey}`)
   } catch (err) {
     this.error = handleError(err)

--- a/src/components/wallet/methods/loadAccount.ts
+++ b/src/components/wallet/methods/loadAccount.ts
@@ -1,4 +1,4 @@
-import { Keypair } from 'stellar-sdk'
+import { Keypair, Networks } from 'stellar-sdk'
 import { set } from '@services/storage'
 import { handleError } from '@services/error'
 import { Wallet } from '../wallet'
@@ -47,7 +47,11 @@ export default async function loadAccount(
     set('WALLET[keystore]', btoa(JSON.stringify(this.account)))
 
     await this.updateAccount()
-    history.replaceState(null, '', `?secretKey=${this.account.secretKey}`)
+    let query = `?secretKey=${this.account.secretKey}`
+    if (this.network_passphrase === Networks.PUBLIC) {
+      query += `&pubnet=true`
+    }
+    history.replaceState(null, '', query)
   } catch (err) {
     this.error = handleError(err)
   }

--- a/src/components/wallet/methods/makePayment.ts
+++ b/src/components/wallet/methods/makePayment.ts
@@ -2,7 +2,6 @@ import {
   Account,
   TransactionBuilder,
   BASE_FEE,
-  Networks,
   Operation,
   Asset,
   Keypair,
@@ -56,7 +55,7 @@ export default async function makePayment(
         const account = new Account(keypair.publicKey(), sequence)
         const transaction = new TransactionBuilder(account, {
           fee: BASE_FEE,
-          networkPassphrase: Networks.TESTNET,
+          networkPassphrase: this.network_passphrase,
         })
           .addOperation(
             Operation.payment({
@@ -81,7 +80,7 @@ export default async function makePayment(
           ) {
             const transaction = new TransactionBuilder(account, {
               fee: BASE_FEE,
-              networkPassphrase: Networks.TESTNET,
+              networkPassphrase: this.network_passphrase,
             })
               .addOperation(
                 Operation.createAccount({

--- a/src/components/wallet/methods/makeRegulatedPayment.tsx
+++ b/src/components/wallet/methods/makeRegulatedPayment.tsx
@@ -2,7 +2,6 @@ import { h } from '@stencil/core'
 import {
   TransactionBuilder,
   Transaction,
-  Networks,
   Operation,
   Server,
   Asset,
@@ -82,7 +81,7 @@ export default async function makeRegulatedPayment(
     const account = await server.loadAccount(keypair.publicKey())
     const transaction = new TransactionBuilder(account, {
       fee: '100',
-      networkPassphrase: Networks.TESTNET,
+      networkPassphrase: this.network_passphrase,
     })
       .addOperation(
         Operation.payment({
@@ -121,7 +120,7 @@ export default async function makeRegulatedPayment(
     }
     //@ts-ignore
     const revisedEnvelope = xdr.TransactionEnvelope.fromXDR(json.tx, 'base64')
-    const revisedTx = new Transaction(revisedEnvelope, Networks.TESTNET)
+    const revisedTx = new Transaction(revisedEnvelope, this.network_passphrase)
     this.logger.instruction(
       'Ask the user to approve revised transaction from approval server',
       TransactionSummary(revisedTx)
@@ -149,7 +148,7 @@ export default async function makeRegulatedPayment(
       finish()
       return
     }
-    const tx = new Transaction(revisedEnvelope, Networks.TESTNET)
+    const tx = new Transaction(revisedEnvelope, this.network_passphrase)
     tx.sign(keypair)
     const labURL = `https://www.stellar.org/laboratory/#xdr-viewer?input=${encodeURIComponent(
       tx.toXDR()

--- a/src/components/wallet/methods/switchNetworks.ts
+++ b/src/components/wallet/methods/switchNetworks.ts
@@ -1,0 +1,33 @@
+import { remove } from '@services/storage'
+import { Wallet } from '../wallet'
+import { Networks } from 'stellar-sdk'
+import { handleError } from '@services/error'
+
+export default async function switchNetworks(
+  this: Wallet,
+  { loggedIn }: { loggedIn: boolean }
+) {
+  try {
+    if (loggedIn) {
+      await this.setPrompt({
+        message: 'You will be signed out, but you can always press back.',
+        inputs: [], // No inputs, by default it displays an empty text field
+      })
+      // flush browser storage
+      await remove('WALLET[keystore]')
+    }
+
+    // remove secretKey param if present and reload
+    let baseURL = location.protocol + '//' + location.host
+    let query = ''
+    if (this.network_passphrase === Networks.TESTNET) {
+      query = '?pubnet=true'
+    }
+    // reloads the app with the new URL
+    // this will trigger componentWillLoad()
+    // which will update this.network_passphrase & this.server
+    location.assign(baseURL + query)
+  } catch (err) {
+    this.error = handleError(err)
+  }
+}

--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -1,7 +1,6 @@
 import {
   TransactionBuilder,
   BASE_FEE,
-  Networks,
   Operation,
   Asset,
   Keypair,
@@ -98,7 +97,7 @@ export default async function trustAsset(
     const account = await this.server.loadAccount(keypair.publicKey())
     const transaction = new TransactionBuilder(account, {
       fee: BASE_FEE,
-      networkPassphrase: Networks.TESTNET,
+      networkPassphrase: this.network_passphrase,
     })
       .addOperation(
         Operation.changeTrust({

--- a/src/components/wallet/methods/withdrawAsset.ts
+++ b/src/components/wallet/methods/withdrawAsset.ts
@@ -3,7 +3,6 @@ import {
   Account,
   TransactionBuilder,
   BASE_FEE,
-  Networks,
   Operation,
   Asset,
   Memo,
@@ -154,7 +153,7 @@ export default async function withdrawAsset(
               const account = new Account(keypair.publicKey(), sequence)
               const txn = new TransactionBuilder(account, {
                 fee: BASE_FEE,
-                networkPassphrase: Networks.TESTNET,
+                networkPassphrase: this.network_passphrase,
               })
                 .addOperation(
                   Operation.payment({

--- a/src/components/wallet/readme.md
+++ b/src/components/wallet/readme.md
@@ -5,11 +5,12 @@
 
 ## Properties
 
-| Property | Attribute | Description | Type                              | Default                                             |
-| -------- | --------- | ----------- | --------------------------------- | --------------------------------------------------- |
-| `assets` | --        |             | `Map<string, WalletAssetDetails>` | `new Map()`                                         |
-| `logger` | --        |             | `ILogger`                         | `MockLogger`                                        |
-| `server` | --        |             | `Server`                          | `new Server('https://horizon-testnet.stellar.org')` |
+| Property             | Attribute            | Description | Type                              | Default                                             |
+| -------------------- | -------------------- | ----------- | --------------------------------- | --------------------------------------------------- |
+| `assets`             | --                   |             | `Map<string, WalletAssetDetails>` | `new Map()`                                         |
+| `logger`             | --                   |             | `ILogger`                         | `MockLogger`                                        |
+| `network_passphrase` | `network_passphrase` |             | `string`                          | `Networks.TESTNET`                                  |
+| `server`             | --                   |             | `Server`                          | `new Server('https://horizon-testnet.stellar.org')` |
 
 
 ## Dependencies

--- a/src/components/wallet/views/loggedInContent.tsx
+++ b/src/components/wallet/views/loggedInContent.tsx
@@ -4,6 +4,7 @@ import { has as loHas } from 'lodash-es'
 import balanceDisplay from './balanceDisplay'
 import claimableDisplay from './claimableDisplay'
 import { Wallet } from '../wallet'
+import { Networks } from 'stellar-sdk'
 
 export default function loggedInContent(this: Wallet) {
   return [
@@ -17,6 +18,15 @@ export default function loggedInContent(this: Wallet) {
       </button>
       <button class="small" type="button" onClick={() => this.copySecret()}>
         Copy Secret
+      </button>
+      <button
+        class="small"
+        type="button"
+        onClick={(_) => this.switchNetworks({ loggedIn: true })}
+      >
+        {this.network_passphrase === Networks.TESTNET
+          ? 'Use Pubnet'
+          : 'Use Testnet'}
       </button>
     </div>,
 

--- a/src/components/wallet/views/loggedOutContent.tsx
+++ b/src/components/wallet/views/loggedOutContent.tsx
@@ -1,21 +1,41 @@
 import { h } from '@stencil/core'
 import { Wallet } from '../wallet'
+import { Networks } from 'stellar-sdk'
 
 export default function loggedOutContent(this: Wallet) {
-  return [
-    <button
-      class={this.loading.create ? 'loading' : null}
-      type="button"
-      onClick={() => this.createAccount()}
-    >
-      {this.loading.create ? <stellar-loader /> : null} Create Account
-    </button>,
+  let content = []
+  // Don't display Create Account button when on mainnet
+  // This is because there is no friendbot on mainnet
+  if (this.network_passphrase === Networks.TESTNET) {
+    content.push(
+      <button
+        class={this.loading.create ? 'loading' : null}
+        type="button"
+        onClick={() => this.createAccount()}
+      >
+        {this.loading.create ? <stellar-loader /> : null} Create Account
+      </button>
+    )
+  }
+  content.push(
     <button
       class={this.loading.load ? 'loading' : null}
       type="button"
       onClick={(_) => this.loadAccount({ displayPrompt: true })}
     >
       {this.loading.load ? <stellar-loader /> : null} Load Account
-    </button>,
-  ]
+    </button>
+  )
+  content.push(
+    <button
+      class={null}
+      type="button"
+      onClick={(_) => this.switchNetworks({ loggedIn: false })}
+    >
+      {this.network_passphrase === Networks.TESTNET
+        ? 'Use Pubnet'
+        : 'Use Testnet'}
+    </button>
+  )
+  return content
 }

--- a/src/components/wallet/wallet.ts
+++ b/src/components/wallet/wallet.ts
@@ -1,5 +1,5 @@
 import { Component, State, Prop } from '@stencil/core'
-import { Server, ServerApi } from 'stellar-sdk'
+import { Server, ServerApi, Networks } from 'stellar-sdk'
 import { ILogger } from '../logview/logview'
 
 import componentWillLoad from './events/componentWillLoad'
@@ -19,6 +19,7 @@ import signOut from './methods/signOut'
 import setPrompt from './methods/setPrompt'
 import loadAccount from './methods/loadAccount'
 import popup from './methods/popup'
+import switchNetworks from './methods/switchNetworks'
 
 import { Prompter } from '@prompt/prompt'
 
@@ -73,6 +74,7 @@ export class Wallet {
   @State() promptContents: string = null
 
   @Prop() server: Server = new Server('https://horizon-testnet.stellar.org')
+  @Prop() network_passphrase: string = Networks.TESTNET
   @Prop() assets: Map<string, WalletAssetDetails> = new Map()
 
   // Component events
@@ -95,6 +97,7 @@ export class Wallet {
   copyAddress = copyAddress
   copySecret = copySecret
   signOut = signOut
+  switchNetworks = switchNetworks
 
   // Misc methods
   setPrompt = setPrompt


### PR DESCRIPTION
resolves stellar/stellar-demo-wallet#53 

Adds a new button to the UI that allows the user to toggle between pubnet and testnet. Defaults to testnet.

Under the hood, clicking this button essentially signs you out (like `signOut()`) and reloads the application with the URL param `pubnet=true` either present or not present. When reloading, `componentWillLoad()` determines what the value of `Wallet.server` and `Wallet.network_passphrase` need to be.

Note that the `Create Account` button is not present when using pubnet. This is because we don't have friendbot on pubnet. We could eventually add functionality to allow the user to create an account from an existing account on mainnet, but for now its not needed.