### PR TITLE
Replace http with https on interactiveResponse and more_info_url

### DIFF
--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -163,8 +163,9 @@ export default async function depositAsset(
     if (!interactiveResponse.url) {
       throw 'No URL Returned from POST /transactions/deposit/interactive'
     }
-
-    const urlBuilder = new URL(interactiveResponse.url)
+    const urlBuilder = new URL(
+      interactiveResponse.url.replace(/^http:\/\//i, 'https://')
+    )
     urlBuilder.searchParams.set('callback', 'postMessage')
     this.logger.instruction(
       'To collect the interactive information we launch the interactive URL in a frame or webview, and await payment details from a postMessage callback'
@@ -183,7 +184,9 @@ export default async function depositAsset(
       } else {
         this.logger.instruction('Transaction status pending...')
         setTimeout(() => {
-          const urlBuilder = new URL(transaction.more_info_url)
+          const urlBuilder = new URL(
+            transaction.more_info_url.replace(/^http:\/\//i, 'https://')
+          )
           urlBuilder.searchParams.set('callback', 'postMessage')
 
           popup.location.href = urlBuilder.toString()

--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -163,9 +163,8 @@ export default async function depositAsset(
     if (!interactiveResponse.url) {
       throw 'No URL Returned from POST /transactions/deposit/interactive'
     }
-    const urlBuilder = new URL(
-      interactiveResponse.url.replace(/^http:\/\//i, 'https://')
-    )
+    const urlBuilder = new URL(interactiveResponse.url)
+    urlBuilder.protocol = 'https'
     urlBuilder.searchParams.set('callback', 'postMessage')
     this.logger.instruction(
       'To collect the interactive information we launch the interactive URL in a frame or webview, and await payment details from a postMessage callback'
@@ -184,9 +183,8 @@ export default async function depositAsset(
       } else {
         this.logger.instruction('Transaction status pending...')
         setTimeout(() => {
-          const urlBuilder = new URL(
-            transaction.more_info_url.replace(/^http:\/\//i, 'https://')
-          )
+          const urlBuilder = new URL(transaction.more_info_url)
+          urlBuilder.protocol = 'https'
           urlBuilder.searchParams.set('callback', 'postMessage')
 
           popup.location.href = urlBuilder.toString()


### PR DESCRIPTION
# Description

In order to debug the demo wallet that is attempting to deposit on a local instance of Polaris (or any other anchor service ran locally).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
 
Depositing fake "offchain assets" to a local instance of Polaris with an SSL proxy (in order to emulate more of a production like behavior)

Signed-off-by: Lawrence Lawson <lawrence@stellar.org>