### PR TITLE
Update strict homedomain protocol requirements

### DIFF
--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -44,10 +44,9 @@ export default async function depositAsset(
       }
       homeDomain = inputs[0].value
     }
-    homeDomain =
-      homeDomain.startsWith('http://') || homeDomain.startsWith('https://')
-        ? homeDomain
-        : 'https://' + homeDomain
+    homeDomain = homeDomain.startsWith('http')
+      ? homeDomain
+      : 'https://' + homeDomain
     const tomlURL = new URL(homeDomain)
     tomlURL.pathname = '/.well-known/stellar.toml'
     this.logger.request(tomlURL.toString())

--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -44,9 +44,10 @@ export default async function depositAsset(
       }
       homeDomain = inputs[0].value
     }
-    homeDomain = (homeDomain.startsWith('http://') || homeDomain.startsWith('https://'))
-      ? homeDomain
-      : 'https://' + homeDomain
+    homeDomain =
+      homeDomain.startsWith('http://') || homeDomain.startsWith('https://')
+        ? homeDomain
+        : 'https://' + homeDomain
     const tomlURL = new URL(homeDomain)
     tomlURL.pathname = '/.well-known/stellar.toml'
     this.logger.request(tomlURL.toString())

--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -51,7 +51,10 @@ export default async function depositAsset(
     const tomlURL = new URL(homeDomain)
     tomlURL.pathname = '/.well-known/stellar.toml'
     this.logger.request(tomlURL.toString())
-    const toml = await StellarTomlResolver.resolve(tomlURL.host)
+    const toml =
+      tomlURL.protocol == 'http:'
+        ? await StellarTomlResolver.resolve(tomlURL.host, { allowHttp: true })
+        : await StellarTomlResolver.resolve(tomlURL.host)
 
     this.logger.instruction(
       `Received WEB_AUTH_ENDPOINT from TOML: ${toml.WEB_AUTH_ENDPOINT}`
@@ -164,7 +167,6 @@ export default async function depositAsset(
       throw 'No URL Returned from POST /transactions/deposit/interactive'
     }
     const urlBuilder = new URL(interactiveResponse.url)
-    urlBuilder.protocol = 'https'
     urlBuilder.searchParams.set('callback', 'postMessage')
     this.logger.instruction(
       'To collect the interactive information we launch the interactive URL in a frame or webview, and await payment details from a postMessage callback'
@@ -184,7 +186,6 @@ export default async function depositAsset(
         this.logger.instruction('Transaction status pending...')
         setTimeout(() => {
           const urlBuilder = new URL(transaction.more_info_url)
-          urlBuilder.protocol = 'https'
           urlBuilder.searchParams.set('callback', 'postMessage')
 
           popup.location.href = urlBuilder.toString()

--- a/src/components/wallet/methods/depositAsset.ts
+++ b/src/components/wallet/methods/depositAsset.ts
@@ -44,8 +44,7 @@ export default async function depositAsset(
       }
       homeDomain = inputs[0].value
     }
-
-    homeDomain = homeDomain.startsWith('https://')
+    homeDomain = (homeDomain.startsWith('http://') || homeDomain.startsWith('https://'))
       ? homeDomain
       : 'https://' + homeDomain
     const tomlURL = new URL(homeDomain)

--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -55,7 +55,12 @@ async function getAssetAndIssuer(wallet: Wallet) {
 
   // if the issuer was not provided, extract if from the home domain's TOML
   if (!issuer && homeDomain) {
-    let toml = await StellarTomlResolver.resolve(homeDomainURL.host)
+    const toml =
+      homeDomainURL.protocol == 'http:'
+        ? await StellarTomlResolver.resolve(homeDomainURL.host, {
+            allowHttp: true,
+          })
+        : await StellarTomlResolver.resolve(homeDomainURL.host)
     if (!toml.CURRENCIES) {
       throw "the home domain specified does not have a CURRENCIES section on it's TOML file"
     }

--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -37,10 +37,9 @@ async function getAssetAndIssuer(wallet: Wallet) {
   }
 
   // if the provided home domain is invalid, throw an error
-  homeDomain =
-    homeDomain.startsWith('http://') || homeDomain.startsWith('https://')
-      ? homeDomain
-      : 'https://' + homeDomain
+  homeDomain = homeDomain.startsWith('http')
+    ? homeDomain
+    : 'https://' + homeDomain
   homeDomain =
     homeDomain[homeDomain.length - 1] !== '/'
       ? homeDomain

--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -37,9 +37,10 @@ async function getAssetAndIssuer(wallet: Wallet) {
   }
 
   // if the provided home domain is invalid, throw an error
-  homeDomain = (homeDomain.startsWith('http://') || homeDomain.startsWith('https://'))
-    ? homeDomain
-    : 'https://' + homeDomain
+  homeDomain =
+    homeDomain.startsWith('http://') || homeDomain.startsWith('https://')
+      ? homeDomain
+      : 'https://' + homeDomain
   homeDomain =
     homeDomain[homeDomain.length - 1] !== '/'
       ? homeDomain

--- a/src/components/wallet/methods/trustAsset.ts
+++ b/src/components/wallet/methods/trustAsset.ts
@@ -37,7 +37,7 @@ async function getAssetAndIssuer(wallet: Wallet) {
   }
 
   // if the provided home domain is invalid, throw an error
-  homeDomain = homeDomain.startsWith('https')
+  homeDomain = (homeDomain.startsWith('http://') || homeDomain.startsWith('https://'))
     ? homeDomain
     : 'https://' + homeDomain
   homeDomain =


### PR DESCRIPTION
# Description

This fixes a blocker I introduced in https://github.com/stellar/stellar-demo-wallet/pull/57 where we force the protocols of the urls we require to be `https`.
This made it impossible to connect a local anchor server(polaris, etc.) to the `stellar-demo-wallet` unless the dev tunneled their local anchor server through a SSL proxy and passed the https url and port.

The following change does not enforce this; instead it will accept http or https protocols and attempt to fetch data from the given location. However if no protocol is given it will assume (and then append) `https://`

### Original Issue Context

In the past whenever I attempted to connect an anchor service to the `stellar-demo-wallet` to a local Polaris server it would fail to fetch the TOML when trusting a dummy asset.

This blocked me from demoing a deposit flow since I could not trust the asset.

The solution was
- Ensure protocols were consistent, meaning `http` stayed `http` and `https` stayed `https`
- Invoke StellarTomlResolver.resolve() correctly; `StellarTomlResolver.resolve(tomlURL.host, { allowHttp: true })` for `http` `StellarTomlResolver.resolve(tomlURL.host)` for `https`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Run `Polaris` locally with `poll_pending_deposits`
1. Create an account 
1.  Deposit deployed assets with https
     - Trust SRT https://testanchor.stellar.org
    - Deposit $10
    - Expected to pass
1. Deposit local assets with http
    - Trust SRT or any other dummy asset http://localhost:8000/
    - Deposit $10
    - Expected to pass
1. Deposit deployed assets without https
    - Trust SRT https://testanchor.stellar.org
    - Deposit $10
    - Expected to pass
1. Deposit local assets without http
    Trust SRT or any other dummy asset localhost:8000/
    - Expected to fail
        - This is by design since it assumes its `https` and appends `https://` on a domain that is is http
        - Then when fetching the `toml` it fails
    ```markdown
    Error in trust transaction
    {
    config: 12 values
    {
    url: https://localhost:8000/.well-known/stellar.toml
    method: get
    headers: 1 values
    transformRequest: 1 values
    transformResponse: 1 values
    timeout: 0
    adapter: Function
    xsrfCookieName: XSRF-TOKEN
    xsrfHeaderName: X-XSRF-TOKEN
    maxContentLength: 102400
    validateStatus: Function
    data: undefined
    }
    request: 0 values
    response: undefined
    isAxiosError: true
    toJSON: Function
    }
    ```