### PR TITLE
Non development env should have hashed file names

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -50,4 +50,5 @@ export const config: Config = {
       '^@prompt/(.*)$': '<rootDir>/src/components/prompt/$1',
     },
   },
+  hashFileNames: process.env.NODE_ENV !== 'development',
 }


### PR DESCRIPTION
Since the assets in upper environments do not change often it is best practice to hash the file names rather than have a simple file name as browser may cache and upon deploying newer changes may not be visible.

<img width="805" alt="image" src="https://user-images.githubusercontent.com/498669/105362358-cd3f5a00-5bc8-11eb-9c1d-eae26373009c.png">
