### PR TITLE
Fix if statement when testing if the asset to add exists

### DIFF
--- a/src/helpers/getUntrustedAssetData.ts
+++ b/src/helpers/getUntrustedAssetData.ts
@@ -45,7 +45,7 @@ export const getUntrustedAssetData = async ({
       .forIssuer(assetIssuer)
       .call();
 
-    if (!assetResponse.records) {
+    if (!assetResponse.records?.length) {
       log.error({ title: `Asset ${assetString} does not exist.` });
     } else {
       log.response({


### PR DESCRIPTION
### What 

Fix if statement when testing if the asset to add exists.

### Why

When trying to add an asset that doesn't exist in horizon's `/assets` we will get an empty list and not a nil list.

```javascript
a = []; console.log(!a);        // prints false
a = []; console.log(!a.length)  // prints true
```