### PR TITLE
SEP-31 support selecting customer types

### DIFF
--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -2,7 +2,7 @@ import { useDispatch } from "react-redux";
 import { TextLink } from "components/TextLink";
 import { BalanceRow } from "components/BalanceRow";
 import { depositAssetAction } from "ducks/sep24DepositAsset";
-import { fetchSendFieldsAction } from "ducks/sep31Send";
+import { initiateSendAction } from "ducks/sep31Send";
 import { withdrawAssetAction } from "ducks/sep24WithdrawAsset";
 import { useRedux } from "hooks/useRedux";
 import {
@@ -70,7 +70,7 @@ export const Balance = ({
   };
 
   const handleSep31Send = (asset: Asset) => {
-    dispatch(fetchSendFieldsAction(asset));
+    dispatch(initiateSendAction(asset));
   };
 
   const handleAction = ({

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import "./styles.scss";
+
+interface RadioButtonProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  label: string;
+}
+
+export const RadioButton = ({ id, label, ...props }: RadioButtonProps) => (
+  <div className="RadioButton">
+    <input type="radio" id={id} {...props} />
+    <label htmlFor={id}>{label}</label>
+  </div>
+);

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -3,7 +3,7 @@ import "./styles.scss";
 
 interface RadioButtonProps extends React.InputHTMLAttributes<HTMLInputElement> {
   id: string;
-  label: string;
+  label: string | React.ReactNode;
 }
 
 export const RadioButton = ({ id, label, ...props }: RadioButtonProps) => (

--- a/src/components/RadioButton/styles.scss
+++ b/src/components/RadioButton/styles.scss
@@ -29,11 +29,17 @@
     position: relative;
     text-transform: none;
 
+    &::before,
+    &::after {
+      flex-shrink: 0;
+      flex-grow: 0;
+    }
+
     &::before {
       content: "";
       display: block;
       margin-right: 0.75rem;
-      margin-top: 0.0625rem;
+      margin-top: 0.1875rem;
       width: 1rem;
       height: 1rem;
       border-radius: 1rem;
@@ -50,7 +56,7 @@
       height: 0.4rem;
       border-radius: 0.4rem;
       margin-left: 0.375rem;
-      margin-top: 0.4375rem;
+      margin-top: 0.52rem;
       position: absolute;
     }
   }

--- a/src/components/RadioButton/styles.scss
+++ b/src/components/RadioButton/styles.scss
@@ -1,0 +1,57 @@
+.RadioButton {
+  display: flex;
+  align-items: center;
+
+  input[type="radio"] {
+    opacity: 0;
+    position: absolute;
+    z-index: -1;
+  }
+
+  input[type="radio"] + label::before {
+    background-color: var(--color-background-input);
+  }
+
+  input[type="radio"]:checked + label::before {
+    background-color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+
+  input[type="radio"]:checked + label::after {
+    background-color: var(--color-background-input);
+  }
+
+  label {
+    font-size: 1rem;
+    line-height: 1.5rem;
+    flex: 1;
+    display: flex;
+    position: relative;
+    text-transform: none;
+
+    &::before {
+      content: "";
+      display: block;
+      margin-right: 0.75rem;
+      margin-top: 0.0625rem;
+      width: 1rem;
+      height: 1rem;
+      border-radius: 1rem;
+      border: 1px solid var(--color-border-input);
+      box-shadow: 0 0.25rem 0.5rem -0.25rem var(--color-shadow);
+      z-index: 1;
+    }
+
+    &::after {
+      content: "";
+      display: block;
+      z-index: 2;
+      width: 0.4rem;
+      height: 0.4rem;
+      border-radius: 0.4rem;
+      margin-left: 0.375rem;
+      margin-top: 0.4375rem;
+      position: absolute;
+    }
+  }
+}

--- a/src/components/Sep31Send.tsx
+++ b/src/components/Sep31Send.tsx
@@ -34,6 +34,7 @@ export const Sep31Send = () => {
     receiver: "",
   });
 
+  const { data } = sep31Send;
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -107,8 +108,11 @@ export const Sep31Send = () => {
     const { sender, receiver } = customerTypes;
     event.preventDefault();
 
-    if (!sender || !receiver) {
-      setErrorMessage("Sender and receiver types are required");
+    if (
+      (data.multipleSenderTypes?.length && !sender) ||
+      (data.multipleReceiverTypes?.length && !receiver)
+    ) {
+      setErrorMessage("Please select sender/receiver type");
       return;
     }
 
@@ -123,9 +127,71 @@ export const Sep31Send = () => {
     dispatch(resetActiveAssetAction());
   };
 
-  if (sep31Send.status === ActionStatus.NEEDS_INPUT) {
-    const { data } = sep31Send;
+  const renderSenderOptions = () => {
+    // Sender type pre-selected
+    if (data.senderType) {
+      return (
+        <p>
+          <code>{data.senderType}</code> was automatically selected
+        </p>
+      );
+    }
 
+    // No sender type required
+    if (!data.senderType && !data.multipleSenderTypes?.length) {
+      return <p>Sender type is not required</p>;
+    }
+
+    // Multiple sender types
+    return data.multipleSenderTypes?.map((sender) => (
+      <RadioButton
+        onChange={() => handleTypeChange(CustomerType.SENDER, sender.type)}
+        key={sender.type}
+        id={sender.type}
+        value={sender.type}
+        name="customer-sender"
+        label={
+          <span className="inline-block">
+            <code>{sender.type}</code> {sender.description}
+          </span>
+        }
+      />
+    ));
+  };
+
+  const renderReceiverOptions = () => {
+    // Receiver type pre-selected
+    if (data.receiverType) {
+      return (
+        <p>
+          <code>{data.receiverType}</code> was automatically selected
+        </p>
+      );
+    }
+
+    // No receiver type required
+    if (!data.receiverType && !data.multipleReceiverTypes?.length) {
+      return <p>Receiver type is not required</p>;
+    }
+
+    // Multiple receiver types
+    return data.multipleReceiverTypes?.map((receiver) => (
+      <RadioButton
+        onChange={() => handleTypeChange(CustomerType.RECEIVER, receiver.type)}
+        key={receiver.type}
+        id={receiver.type}
+        value={receiver.type}
+        name="customer-receiver"
+        label={
+          <span className="inline-block">
+            <code>{receiver.type}</code> {receiver.description}
+          </span>
+        }
+      />
+    ));
+  };
+
+  if (sep31Send.status === ActionStatus.NEEDS_INPUT) {
     // Select customer types
     if (!data.isTypeSelected) {
       return (
@@ -144,54 +210,12 @@ export const Sep31Send = () => {
 
             <div>
               <Heading3>Sender</Heading3>
-              {data.multipleSenderTypes?.map((sender) => (
-                <RadioButton
-                  onChange={() =>
-                    handleTypeChange(CustomerType.SENDER, sender.type)
-                  }
-                  key={sender.type}
-                  id={sender.type}
-                  value={sender.type}
-                  name="customer-sender"
-                  label={
-                    <span className="inline-block">
-                      <code>{sender.type}</code> {sender.description}
-                    </span>
-                  }
-                />
-              ))}
-
-              {data.senderType && (
-                <p>
-                  <code>{data.senderType}</code> was automatically selected
-                </p>
-              )}
+              {renderSenderOptions()}
             </div>
 
             <div>
               <Heading3>Receiver</Heading3>
-              {data.multipleReceiverTypes?.map((receiver) => (
-                <RadioButton
-                  onChange={() =>
-                    handleTypeChange(CustomerType.RECEIVER, receiver.type)
-                  }
-                  key={receiver.type}
-                  id={receiver.type}
-                  value={receiver.type}
-                  name="customer-receiver"
-                  label={
-                    <span className="inline-block">
-                      <code>{receiver.type}</code> {receiver.description}
-                    </span>
-                  }
-                />
-              ))}
-
-              {data.receiverType && (
-                <p>
-                  <code>{data.receiverType}</code> was automatically selected
-                </p>
-              )}
+              {renderReceiverOptions()}
             </div>
 
             {errorMessage && <p className="error">{errorMessage}</p>}

--- a/src/components/Sep31Send.tsx
+++ b/src/components/Sep31Send.tsx
@@ -130,11 +130,18 @@ export const Sep31Send = () => {
     if (!data.isTypeSelected) {
       return (
         <Modal visible={true} onClose={handleClose}>
-          <Heading2 className="ModalHeading">
-            Sender and receiver types
-          </Heading2>
+          <Heading2>Customer Types</Heading2>
 
           <div className="ModalBody">
+            <p>
+              Receiving anchors are required to collect Know Your Customer (KYC)
+              information on the customers involved in a transaction. Each type
+              described below corresponds to a different set of KYC values the
+              anchor will request the sending anchor to provide. This demo
+              wallet, which acts as a sending anchor, will provide you a form to
+              enter the fields corresponding to the type selected.
+            </p>
+
             <div>
               <Heading3>Sender</Heading3>
               {data.multipleSenderTypes?.map((sender) => (
@@ -153,6 +160,12 @@ export const Sep31Send = () => {
                   }
                 />
               ))}
+
+              {data.senderType && (
+                <p>
+                  <code>{data.senderType}</code> was automatically selected
+                </p>
+              )}
             </div>
 
             <div>
@@ -173,6 +186,12 @@ export const Sep31Send = () => {
                   }
                 />
               ))}
+
+              {data.receiverType && (
+                <p>
+                  <code>{data.receiverType}</code> was automatically selected
+                </p>
+              )}
             </div>
 
             {errorMessage && <p className="error">{errorMessage}</p>}

--- a/src/components/Sep31Send.tsx
+++ b/src/components/Sep31Send.tsx
@@ -17,6 +17,11 @@ import { capitalizeString } from "helpers/capitalizeString";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus } from "types/types.d";
 
+enum CustomerType {
+  SENDER = "sender",
+  RECEIVER = "receiver",
+}
+
 export const Sep31Send = () => {
   const { account, sep31Send } = useRedux("account", "sep31Send");
   const [formData, setFormData] = useState<any>({});
@@ -79,7 +84,7 @@ export const Sep31Send = () => {
     setFormData(updatedState);
   };
 
-  const handleTypeChange = (type: "sender" | "receiver", typeId: string) => {
+  const handleTypeChange = (type: CustomerType, typeId: string) => {
     const updatedTypes = {
       ...customerTypes,
       [type]: typeId,
@@ -134,7 +139,9 @@ export const Sep31Send = () => {
               <Heading3>Sender</Heading3>
               {data.multipleSenderTypes?.map((sender) => (
                 <RadioButton
-                  onChange={() => handleTypeChange("sender", sender.type)}
+                  onChange={() =>
+                    handleTypeChange(CustomerType.SENDER, sender.type)
+                  }
                   key={sender.type}
                   id={sender.type}
                   value={sender.type}
@@ -152,7 +159,9 @@ export const Sep31Send = () => {
               <Heading3>Receiver</Heading3>
               {data.multipleReceiverTypes?.map((receiver) => (
                 <RadioButton
-                  onChange={() => handleTypeChange("receiver", receiver.type)}
+                  onChange={() =>
+                    handleTypeChange(CustomerType.RECEIVER, receiver.type)
+                  }
                   key={receiver.type}
                   id={receiver.type}
                   value={receiver.type}

--- a/src/ducks/sep31Send.ts
+++ b/src/ducks/sep31Send.ts
@@ -26,7 +26,7 @@ import {
   Asset,
   ActionStatus,
   AnyObject,
-  CustomerType,
+  CustomerTypeItem,
   Sep31SendInitialState,
   RejectMessage,
   TomlFields,
@@ -44,8 +44,8 @@ interface InitiateSendActionResponse {
   };
   senderType: string | undefined;
   receiverType: string | undefined;
-  multipleSenderTypes: CustomerType[] | undefined;
-  multipleReceiverTypes: CustomerType[] | undefined;
+  multipleSenderTypes: CustomerTypeItem[] | undefined;
+  multipleReceiverTypes: CustomerTypeItem[] | undefined;
   authEndpoint: string;
   sendServer: string;
   kycServer: string;

--- a/src/methods/sep31Send/getSep12Fields.ts
+++ b/src/methods/sep31Send/getSep12Fields.ts
@@ -3,15 +3,15 @@ import { log } from "helpers/log";
 
 export const getSep12Fields = async ({
   kycServer,
-  receiverSep12Type,
+  receiverType,
   publicKey,
-  senderSep12Type,
+  senderType,
   token,
 }: {
   kycServer: string;
-  receiverSep12Type: string;
+  receiverType: string | undefined;
   publicKey: string;
-  senderSep12Type: string;
+  senderType: string | undefined;
   token: string;
 }) => {
   log.instruction({
@@ -27,11 +27,11 @@ export const getSep12Fields = async ({
     },
   };
 
-  if (senderSep12Type) {
+  if (senderType) {
     const memo = crypto.randomBytes(32).toString("base64");
 
     result.senderSep12Fields = await collectSep12Fields({
-      type: senderSep12Type,
+      type: senderType,
       memo,
       publicKey,
       token,
@@ -41,11 +41,11 @@ export const getSep12Fields = async ({
     result.info.senderSep12Memo = memo;
   }
 
-  if (receiverSep12Type) {
+  if (receiverType) {
     const memo = crypto.randomBytes(32).toString("base64");
 
     result.receiverSep12Fields = await collectSep12Fields({
-      type: receiverSep12Type,
+      type: receiverType,
       memo,
       publicKey,
       token,

--- a/src/methods/sep31Send/putSep12Fields.ts
+++ b/src/methods/sep31Send/putSep12Fields.ts
@@ -4,8 +4,8 @@ import { log } from "helpers/log";
 interface PutSep12FieldsProps {
   formData: any;
   secretKey: string;
-  senderSep12Memo: string;
-  receiverSep12Memo: string;
+  senderMemo: string;
+  receiverMemo: string;
   fields: any;
   token: string;
   kycServer: string;
@@ -14,8 +14,8 @@ interface PutSep12FieldsProps {
 export const putSep12Fields = async ({
   formData,
   secretKey,
-  senderSep12Memo,
-  receiverSep12Memo,
+  senderMemo,
+  receiverMemo,
   fields,
   token,
   kycServer,
@@ -33,7 +33,7 @@ export const putSep12Fields = async ({
     const resultJson = await putSep12FieldsRequest({
       secretKey,
       fields: formData.sender,
-      memo: senderSep12Memo,
+      memo: senderMemo,
       token,
       kycServer,
       isSender: true,
@@ -46,7 +46,7 @@ export const putSep12Fields = async ({
     const resultJson = await putSep12FieldsRequest({
       secretKey,
       fields: formData.receiver,
-      memo: receiverSep12Memo,
+      memo: receiverMemo,
       token,
       kycServer,
       isSender: false,

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -155,7 +155,7 @@ export interface NestedStringObject {
   };
 }
 
-export interface CustomerType {
+export interface CustomerTypeItem {
   type: string;
   description: string;
 }
@@ -177,8 +177,8 @@ export interface Sep31SendInitialState {
     receiverType: string | undefined;
     senderMemo: string;
     receiverMemo: string;
-    multipleSenderTypes: CustomerType[] | undefined;
-    multipleReceiverTypes: CustomerType[] | undefined;
+    multipleSenderTypes: CustomerTypeItem[] | undefined;
+    multipleReceiverTypes: CustomerTypeItem[] | undefined;
     authEndpoint: string;
     sendServer: string;
     kycServer: string;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -155,8 +155,15 @@ export interface NestedStringObject {
   };
 }
 
+export interface CustomerType {
+  type: string;
+  description: string;
+}
+
 export interface Sep31SendInitialState {
   data: {
+    publicKey: string;
+    homeDomain: string;
     assetCode: string;
     assetIssuer: string;
     token: string;
@@ -165,13 +172,17 @@ export interface Sep31SendInitialState {
       sender: AnyObject;
       receiver: AnyObject;
     };
-    senderSep12Type: string;
-    receiverSep12Type: string;
-    senderSep12Memo: string;
-    receiverSep12Memo: string;
+    isTypeSelected: boolean;
+    senderType: string | undefined;
+    receiverType: string | undefined;
+    senderMemo: string;
+    receiverMemo: string;
+    multipleSenderTypes: CustomerType[] | undefined;
+    multipleReceiverTypes: CustomerType[] | undefined;
     authEndpoint: string;
     sendServer: string;
     kycServer: string;
+    serverSigningKey: string;
   };
   errorString?: string;
   status: ActionStatus | undefined;
@@ -245,6 +256,7 @@ export enum ActionStatus {
   PENDING = "PENDING",
   SUCCESS = "SUCCESS",
   NEEDS_INPUT = "NEEDS_INPUT",
+  CAN_PROCEED = "CAN_PROCEED",
 }
 
 export interface RejectMessage {


### PR DESCRIPTION
- Updated `sep31Send` flow to add an extra step for selecting customer type (if there are multiple options available).
- Added `CAN_PROCEED` status to `ActionStatus`, which is similar to `SUCCESS` but happens during the process (`SUCCESS` should happen only once at the end of the process).
- Added `RadioButton` component.
- Added a modal to select sender/receiver types.

![image](https://user-images.githubusercontent.com/7346473/116446063-96f72380-a824-11eb-933d-815d4754c575.png)