### PR TITLE
Support SEP-8 "Action Required" flow

### DIFF
--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { Button, Input, Loader } from "@stellar/design-system";
+import { Heading2 } from "components/Heading";
+import { Modal } from "components/Modal";
+import { useRedux } from "hooks/useRedux";
+import { ActionStatus } from "types/types.d";
+
+export const Sep8ActionRequiredForm = ({
+  onClose,
+}: {
+  onClose: () => void;
+}) => {
+  const { sep8Send } = useRedux("sep8Send");
+  const [fieldValues, setFieldValues] = useState<{ [key: string]: string }>({});
+  const { actionFields, message } = sep8Send.data.actionRequired;
+
+  // user interaction handlers
+  const handleSubmitActionRequiredFields = () => {
+    console.log("TODO: handleSubmitActionRequiredFields");
+  };
+
+  const handleGetFieldValue = ({ fieldName }: { fieldName: string }) =>
+    fieldValues[fieldName];
+
+  const handleSetFieldValue = ({
+    fieldName,
+    fieldValue,
+  }: {
+    fieldName: string;
+    fieldValue: string;
+  }) => {
+    const buffFieldValue = { ...fieldValues };
+    buffFieldValue[fieldName] = fieldValue;
+    setFieldValues(buffFieldValue);
+  };
+
+  const renderSendPayment = () => (
+    <>
+      <Heading2 className="ModalHeading">SEP-8 Action Required</Heading2>
+
+      <div className="ModalBody">
+        <div className="ModalMessage">
+          <p>{message}</p>
+        </div>
+
+        <div className="ModalMessage">
+          <p>The following information is needed before we can proceed:</p>
+        </div>
+
+        {actionFields.map((fieldName) => (
+          <Input
+            id={`sep8-action-field-${fieldName}`}
+            label={fieldName}
+            onChange={(e) =>
+              handleSetFieldValue({ fieldName, fieldValue: e.target.value })
+            }
+            value={handleGetFieldValue({ fieldName })}
+          />
+        ))}
+
+        {sep8Send.errorString && (
+          <div className="ModalMessage error">
+            <p>{sep8Send.errorString}</p>
+          </div>
+        )}
+      </div>
+
+      <div className="ModalButtonsFooter">
+        {sep8Send.status === ActionStatus.PENDING && <Loader />}
+
+        <Button
+          onClick={handleSubmitActionRequiredFields}
+          disabled={sep8Send.status === ActionStatus.PENDING}
+        >
+          Submit
+        </Button>
+      </div>
+    </>
+  );
+
+  return (
+    <Modal onClose={onClose} visible>
+      {renderSendPayment()}
+    </Modal>
+  );
+};

--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -5,7 +5,7 @@ import { Heading2 } from "components/Heading";
 import { Modal } from "components/Modal";
 import {
   initiateSep8SendAction,
-  sep8SendActionRequiredParamsAction,
+  sep8SendActionRequiredFieldsAction,
 } from "ducks/sep8Send";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus, Sep8Step } from "types/types.d";
@@ -27,7 +27,7 @@ export const Sep8ActionRequiredForm = ({
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (sep8Send.data.sep8Step === Sep8Step.SENT_ACTION_REQUIRED_PARAMS) {
+    if (sep8Send.data.sep8Step === Sep8Step.SENT_ACTION_REQUIRED_FIELDS) {
       if (result === "follow_next_url") {
         window.open(nextUrl, "_blank");
       }
@@ -55,7 +55,7 @@ export const Sep8ActionRequiredForm = ({
 
   const handleSubmitActionRequiredFields = () => {
     dispatch(
-      sep8SendActionRequiredParamsAction({
+      sep8SendActionRequiredFieldsAction({
         actionFields: fieldValues,
         actionMethod,
         actionUrl,
@@ -63,10 +63,7 @@ export const Sep8ActionRequiredForm = ({
     );
   };
 
-  const handleGetFieldValue = ({ fieldName }: { fieldName: string }) =>
-    fieldValues[fieldName] || "";
-
-  const handleSetFieldValue = ({
+  const handleOnChangeField = ({
     fieldName,
     fieldValue,
   }: {
@@ -97,9 +94,9 @@ export const Sep8ActionRequiredForm = ({
             id={`sep8-action-field-${fieldName}`}
             label={fieldName}
             onChange={(e) =>
-              handleSetFieldValue({ fieldName, fieldValue: e.target.value })
+              handleOnChangeField({ fieldName, fieldValue: e.target.value })
             }
-            value={handleGetFieldValue({ fieldName })}
+            value={fieldValues[fieldName] || ""}
           />
         ))}
 

--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -8,7 +8,11 @@ import {
   sep8SendActionRequiredFieldsAction,
 } from "ducks/sep8Send";
 import { useRedux } from "hooks/useRedux";
-import { ActionStatus, Sep8Step } from "types/types.d";
+import {
+  ActionStatus,
+  Sep8ActionRequiredResultType,
+  Sep8Step,
+} from "types/types.d";
 
 export const Sep8ActionRequiredForm = ({
   onClose,
@@ -28,7 +32,7 @@ export const Sep8ActionRequiredForm = ({
 
   useEffect(() => {
     if (sep8Send.data.sep8Step === Sep8Step.SENT_ACTION_REQUIRED_FIELDS) {
-      if (result === "follow_next_url") {
+      if (result === Sep8ActionRequiredResultType.NO_FURTHER_ACTION_REQUIRED) {
         window.open(nextUrl, "_blank");
       }
 

--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -3,7 +3,10 @@ import { useDispatch } from "react-redux";
 import { Button, Input, Loader } from "@stellar/design-system";
 import { Heading2 } from "components/Heading";
 import { Modal } from "components/Modal";
-import { sep8SendActionRequiredParamsAction } from "ducks/sep8Send";
+import {
+  sep8ReviseTransactionAction,
+  sep8SendActionRequiredParamsAction,
+} from "ducks/sep8Send";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus } from "types/types.d";
 
@@ -12,7 +15,7 @@ export const Sep8ActionRequiredForm = ({
 }: {
   onClose: () => void;
 }) => {
-  const { sep8Send } = useRedux("sep8Send");
+  const { account, sep8Send } = useRedux("account", "sep8Send");
   const [fieldValues, setFieldValues] = useState<{ [key: string]: string }>({});
   const {
     actionFields,
@@ -32,8 +35,34 @@ export const Sep8ActionRequiredForm = ({
       window.open(nextUrl, "_blank");
     }
 
+    if (account.data) {
+      dispatch(
+        sep8ReviseTransactionAction({
+          amount: sep8Send.data.revisedTransaction.amount,
+          approvalServer: sep8Send.data.approvalServer,
+          assetCode: sep8Send.data.assetCode,
+          assetIssuer: sep8Send.data.assetIssuer,
+          destination: sep8Send.data.revisedTransaction.destination,
+          isDestinationFunded: true,
+          publicKey: account.data?.id,
+        }),
+      );
+    }
+
     onClose();
-  }, [nextUrl, onClose, result, sep8Send.status]);
+  }, [
+    account.data,
+    dispatch,
+    nextUrl,
+    onClose,
+    result,
+    sep8Send.data.revisedTransaction.amount,
+    sep8Send.data.approvalServer,
+    sep8Send.data.assetCode,
+    sep8Send.data.assetIssuer,
+    sep8Send.data.revisedTransaction.destination,
+    sep8Send.status,
+  ]);
 
   const handleSubmitActionRequiredFields = () => {
     dispatch(

--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -12,7 +12,7 @@ export const Sep8ActionRequiredForm = ({
 }) => {
   const { sep8Send } = useRedux("sep8Send");
   const [fieldValues, setFieldValues] = useState<{ [key: string]: string }>({});
-  const { actionFields, message } = sep8Send.data.actionRequired;
+  const { actionFields, message } = sep8Send.data.actionRequiredInfo;
 
   // user interaction handlers
   const handleSubmitActionRequiredFields = () => {

--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -1,7 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 import { Button, Input, Loader } from "@stellar/design-system";
 import { Heading2 } from "components/Heading";
 import { Modal } from "components/Modal";
+import { sep8SendActionRequiredParamsAction } from "ducks/sep8Send";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus } from "types/types.d";
 
@@ -12,15 +14,39 @@ export const Sep8ActionRequiredForm = ({
 }) => {
   const { sep8Send } = useRedux("sep8Send");
   const [fieldValues, setFieldValues] = useState<{ [key: string]: string }>({});
-  const { actionFields, message } = sep8Send.data.actionRequiredInfo;
+  const {
+    actionFields,
+    message,
+    actionMethod,
+    actionUrl,
+  } = sep8Send.data.actionRequiredInfo;
+  const { nextUrl, result } = sep8Send.data.actionRequiredResult;
+  const dispatch = useDispatch();
 
-  // user interaction handlers
+  useEffect(() => {
+    if (sep8Send.status !== ActionStatus.SUCCESS) {
+      return;
+    }
+
+    if (result === "follow_next_url") {
+      window.open(nextUrl, "_blank");
+    }
+
+    onClose();
+  }, [nextUrl, onClose, result, sep8Send.status]);
+
   const handleSubmitActionRequiredFields = () => {
-    console.log("TODO: handleSubmitActionRequiredFields");
+    dispatch(
+      sep8SendActionRequiredParamsAction({
+        actionFields: fieldValues,
+        actionMethod,
+        actionUrl,
+      }),
+    );
   };
 
   const handleGetFieldValue = ({ fieldName }: { fieldName: string }) =>
-    fieldValues[fieldName];
+    fieldValues[fieldName] || "";
 
   const handleSetFieldValue = ({
     fieldName,
@@ -49,6 +75,7 @@ export const Sep8ActionRequiredForm = ({
 
         {actionFields.map((fieldName) => (
           <Input
+            key={fieldName}
             id={`sep8-action-field-${fieldName}`}
             label={fieldName}
             onChange={(e) =>

--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -4,11 +4,11 @@ import { Button, Input, Loader } from "@stellar/design-system";
 import { Heading2 } from "components/Heading";
 import { Modal } from "components/Modal";
 import {
-  sep8ReviseTransactionAction,
+  initiateSep8SendAction,
   sep8SendActionRequiredParamsAction,
 } from "ducks/sep8Send";
 import { useRedux } from "hooks/useRedux";
-import { ActionStatus } from "types/types.d";
+import { ActionStatus, Sep8Step } from "types/types.d";
 
 export const Sep8ActionRequiredForm = ({
   onClose,
@@ -27,41 +27,30 @@ export const Sep8ActionRequiredForm = ({
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (sep8Send.status !== ActionStatus.SUCCESS) {
-      return;
-    }
+    if (sep8Send.data.sep8Step === Sep8Step.SENT_ACTION_REQUIRED_PARAMS) {
+      if (result === "follow_next_url") {
+        window.open(nextUrl, "_blank");
+      }
 
-    if (result === "follow_next_url") {
-      window.open(nextUrl, "_blank");
+      if (account.data) {
+        dispatch(
+          initiateSep8SendAction({
+            assetCode: sep8Send.data.assetCode,
+            assetIssuer: sep8Send.data.assetIssuer,
+            homeDomain: sep8Send.data.homeDomain,
+          }),
+        );
+      }
     }
-
-    if (account.data) {
-      dispatch(
-        sep8ReviseTransactionAction({
-          amount: sep8Send.data.revisedTransaction.amount,
-          approvalServer: sep8Send.data.approvalServer,
-          assetCode: sep8Send.data.assetCode,
-          assetIssuer: sep8Send.data.assetIssuer,
-          destination: sep8Send.data.revisedTransaction.destination,
-          isDestinationFunded: true,
-          publicKey: account.data?.id,
-        }),
-      );
-    }
-
-    onClose();
   }, [
     account.data,
     dispatch,
     nextUrl,
-    onClose,
     result,
-    sep8Send.data.revisedTransaction.amount,
-    sep8Send.data.approvalServer,
     sep8Send.data.assetCode,
     sep8Send.data.assetIssuer,
-    sep8Send.data.revisedTransaction.destination,
-    sep8Send.status,
+    sep8Send.data.homeDomain,
+    sep8Send.data.sep8Step,
   ]);
 
   const handleSubmitActionRequiredFields = () => {

--- a/src/components/Sep8Send/Sep8Approval.tsx
+++ b/src/components/Sep8Send/Sep8Approval.tsx
@@ -17,7 +17,7 @@ import {
 } from "ducks/sep8Send";
 import { getNetworkConfig } from "helpers/getNetworkConfig";
 import { useRedux } from "hooks/useRedux";
-import { ActionStatus } from "types/types.d";
+import { ActionStatus, Sep8Step } from "types/types.d";
 
 export const Sep8Approval = ({ onClose }: { onClose: () => void }) => {
   const { account, sep8Send, settings } = useRedux(
@@ -27,9 +27,17 @@ export const Sep8Approval = ({ onClose }: { onClose: () => void }) => {
   );
   const dispatch = useDispatch();
 
+  const {
+    approvalCriteria,
+    approvalServer,
+    assetCode,
+    assetIssuer,
+  } = sep8Send.data;
   // form data
-  const [amount, setAmount] = useState("");
-  const [destination, setDestination] = useState("");
+  const [amount, setAmount] = useState(sep8Send.data.revisedTransaction.amount);
+  const [destination, setDestination] = useState(
+    sep8Send.data.revisedTransaction.destination,
+  );
   const [isDestinationFunded, setIsDestinationFunded] = useState(true);
 
   const resetFormState = () => {
@@ -38,12 +46,11 @@ export const Sep8Approval = ({ onClose }: { onClose: () => void }) => {
     setIsDestinationFunded(true);
   };
 
-  const {
-    approvalCriteria,
-    approvalServer,
-    assetCode,
-    assetIssuer,
-  } = sep8Send.data;
+  useEffect(() => {
+    if (sep8Send.data.sep8Step === Sep8Step.PENDING) {
+      onClose();
+    }
+  }, [onClose, sep8Send.data.sep8Step]);
 
   // user interaction handlers
   const handleSubmitPayment = () => {
@@ -66,16 +73,6 @@ export const Sep8Approval = ({ onClose }: { onClose: () => void }) => {
     resetFormState();
     onClose();
   };
-
-  // use effect
-  useEffect(() => {
-    if (
-      sep8Send.status === ActionStatus.CAN_PROCEED &&
-      sep8Send.data.revisedTransaction.revisedTxXdr
-    ) {
-      resetFormState();
-    }
-  }, [sep8Send.status, sep8Send.data.revisedTransaction.revisedTxXdr]);
 
   // helper function(s)
   const checkAndSetIsDestinationFunded = async () => {

--- a/src/components/Sep8Send/Sep8Approval.tsx
+++ b/src/components/Sep8Send/Sep8Approval.tsx
@@ -25,20 +25,18 @@ export const Sep8Approval = ({ onClose }: { onClose: () => void }) => {
     "sep8Send",
     "settings",
   );
-  const dispatch = useDispatch();
-
   const {
     approvalCriteria,
     approvalServer,
     assetCode,
     assetIssuer,
   } = sep8Send.data;
-  // form data
   const [amount, setAmount] = useState(sep8Send.data.revisedTransaction.amount);
   const [destination, setDestination] = useState(
     sep8Send.data.revisedTransaction.destination,
   );
   const [isDestinationFunded, setIsDestinationFunded] = useState(true);
+  const dispatch = useDispatch();
 
   const resetFormState = () => {
     setDestination("");

--- a/src/components/Sep8Send/Sep8Review.tsx
+++ b/src/components/Sep8Send/Sep8Review.tsx
@@ -22,6 +22,7 @@ export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
   const [isApproved, setIsApproved] = useState(false);
   const dispatch = useDispatch();
   const { revisedTxXdr, submittedTxXdr } = sep8Send.data.revisedTransaction;
+  const { sep8Step } = sep8Send.data;
 
   // user interaction handlers
   const handleSubmitPayment = () => {
@@ -32,7 +33,7 @@ export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
 
   // use effect: complete action, close modal and refresh account balances
   useEffect(() => {
-    if (sep8Send.data.sep8Step === Sep8Step.COMPLETE && account.data?.id) {
+    if (sep8Step === Sep8Step.COMPLETE && account.data?.id) {
       dispatch(
         fetchAccountAction({
           publicKey: account.data.id,
@@ -41,13 +42,7 @@ export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
       );
       onClose();
     }
-  }, [
-    account.data?.id,
-    account.secretKey,
-    sep8Send.data.sep8Step,
-    dispatch,
-    onClose,
-  ]);
+  }, [account.data?.id, account.secretKey, dispatch, onClose, sep8Step]);
 
   // use effect: parse transaction XDRs
   useEffect(() => {

--- a/src/components/Sep8Send/Sep8Review.tsx
+++ b/src/components/Sep8Send/Sep8Review.tsx
@@ -9,7 +9,7 @@ import { fetchAccountAction } from "ducks/account";
 import { sep8SubmitRevisedTransactionAction } from "ducks/sep8Send";
 import { getNetworkConfig } from "helpers/getNetworkConfig";
 import { useRedux } from "hooks/useRedux";
-import { ActionStatus } from "types/types.d";
+import { ActionStatus, Sep8Step } from "types/types.d";
 
 export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
   const { account, sep8Send, settings } = useRedux(
@@ -32,7 +32,7 @@ export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
 
   // use effect: complete action, close modal and refresh account balances
   useEffect(() => {
-    if (sep8Send.status === ActionStatus.SUCCESS && account.data?.id) {
+    if (sep8Send.data.sep8Step === Sep8Step.COMPLETE && account.data?.id) {
       dispatch(
         fetchAccountAction({
           publicKey: account.data.id,
@@ -41,7 +41,13 @@ export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
       );
       onClose();
     }
-  }, [account.data?.id, account.secretKey, sep8Send.status, dispatch, onClose]);
+  }, [
+    account.data?.id,
+    account.secretKey,
+    sep8Send.data.sep8Step,
+    dispatch,
+    onClose,
+  ]);
 
   // use effect: parse transaction XDRs
   useEffect(() => {

--- a/src/components/Sep8Send/index.tsx
+++ b/src/components/Sep8Send/index.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { useDispatch } from "react-redux";
 import { Sep8ActionRequiredForm } from "components/Sep8Send/Sep8ActionRequiredForm";
 import { Sep8Approval } from "components/Sep8Send/Sep8Approval";
@@ -10,29 +9,28 @@ import { Sep8Step } from "types/types.d";
 
 export const Sep8Send = () => {
   const { sep8Send } = useRedux("sep8Send");
+  const sep8Step = sep8Send.data.sep8Step;
   const dispatch = useDispatch();
 
-  const onClose = useCallback(() => {
+  const onClose = () => {
     dispatch(resetActiveAssetAction());
     dispatch(resetSep8SendAction());
-  }, [dispatch]);
+  };
 
   return (
     <>
-      {(sep8Send.data.sep8Step === Sep8Step.STARTING ||
-        sep8Send.data.sep8Step === Sep8Step.PENDING) && (
+      {[Sep8Step.STARTING, Sep8Step.PENDING].includes(sep8Step) && (
         <Sep8Approval onClose={onClose} />
       )}
 
-      {(sep8Send.data.sep8Step === Sep8Step.TRANSACTION_REVISED ||
-        sep8Send.data.sep8Step === Sep8Step.COMPLETE) && (
+      {[Sep8Step.TRANSACTION_REVISED, Sep8Step.COMPLETE].includes(sep8Step) && (
         <Sep8Review onClose={onClose} />
       )}
 
-      {(sep8Send.data.sep8Step === Sep8Step.ACTION_REQUIRED ||
-        sep8Send.data.sep8Step === Sep8Step.SENT_ACTION_REQUIRED_PARAMS) && (
-        <Sep8ActionRequiredForm onClose={onClose} />
-      )}
+      {[
+        Sep8Step.ACTION_REQUIRED,
+        Sep8Step.SENT_ACTION_REQUIRED_FIELDS,
+      ].includes(sep8Step) && <Sep8ActionRequiredForm onClose={onClose} />}
     </>
   );
 };

--- a/src/components/Sep8Send/index.tsx
+++ b/src/components/Sep8Send/index.tsx
@@ -1,63 +1,36 @@
-import { useEffect, useState } from "react";
+import { useCallback } from "react";
 import { useDispatch } from "react-redux";
+import { Sep8ActionRequiredForm } from "components/Sep8Send/Sep8ActionRequiredForm";
 import { Sep8Approval } from "components/Sep8Send/Sep8Approval";
 import { Sep8Review } from "components/Sep8Send/Sep8Review";
 import { resetActiveAssetAction } from "ducks/activeAsset";
 import { resetSep8SendAction } from "ducks/sep8Send";
 import { useRedux } from "hooks/useRedux";
-import { ActionStatus } from "types/types.d";
-import { Sep8ActionRequiredForm } from "./Sep8ActionRequiredForm";
+import { Sep8Step } from "types/types.d";
 
 export const Sep8Send = () => {
   const { sep8Send } = useRedux("sep8Send");
-  const [approvalModalVisible, setApprovalModalVisible] = useState(false);
-  const [reviewModalVisible, setReviewModalVisible] = useState(false);
-  const [actionRequiredModalVisible, setActionRequiredModalVisible] = useState(
-    false,
-  );
   const dispatch = useDispatch();
 
-  const onClose = () => {
-    setApprovalModalVisible(false);
+  const onClose = useCallback(() => {
     dispatch(resetActiveAssetAction());
     dispatch(resetSep8SendAction());
-  };
-
-  // use effect
-  useEffect(() => {
-    if (!sep8Send.status) {
-      setReviewModalVisible(false);
-      setApprovalModalVisible(false);
-      setActionRequiredModalVisible(false);
-      return;
-    }
-
-    if (sep8Send.status !== ActionStatus.CAN_PROCEED) {
-      return;
-    }
-
-    const hasTxToRevise = Boolean(
-      sep8Send.data.revisedTransaction.revisedTxXdr,
-    );
-    const hasPendingActionRequired = Boolean(
-      sep8Send.data.actionRequiredInfo.actionFields.length,
-    );
-    setApprovalModalVisible(!hasTxToRevise && !hasPendingActionRequired);
-    setReviewModalVisible(hasTxToRevise);
-    setActionRequiredModalVisible(hasPendingActionRequired && !hasTxToRevise);
-  }, [
-    sep8Send.status,
-    sep8Send.data.revisedTransaction.revisedTxXdr,
-    sep8Send.data.actionRequiredInfo.actionFields,
-  ]);
+  }, [dispatch]);
 
   return (
     <>
-      {approvalModalVisible && <Sep8Approval onClose={onClose} />}
+      {(sep8Send.data.sep8Step === Sep8Step.STARTING ||
+        sep8Send.data.sep8Step === Sep8Step.PENDING) && (
+        <Sep8Approval onClose={onClose} />
+      )}
 
-      {reviewModalVisible && <Sep8Review onClose={onClose} />}
+      {(sep8Send.data.sep8Step === Sep8Step.TRANSACTION_REVISED ||
+        sep8Send.data.sep8Step === Sep8Step.COMPLETE) && (
+        <Sep8Review onClose={onClose} />
+      )}
 
-      {actionRequiredModalVisible && (
+      {(sep8Send.data.sep8Step === Sep8Step.ACTION_REQUIRED ||
+        sep8Send.data.sep8Step === Sep8Step.SENT_ACTION_REQUIRED_PARAMS) && (
         <Sep8ActionRequiredForm onClose={onClose} />
       )}
     </>

--- a/src/components/Sep8Send/index.tsx
+++ b/src/components/Sep8Send/index.tsx
@@ -40,7 +40,7 @@ export const Sep8Send = () => {
       sep8Send.data.revisedTransaction.revisedTxXdr,
     );
     const hasPendingActionRequired = Boolean(
-      sep8Send.data.actionRequired.actionFields.length,
+      sep8Send.data.actionRequiredInfo.actionFields.length,
     );
     setApprovalModalVisible(!hasTxToRevise && !hasPendingActionRequired);
     setReviewModalVisible(hasTxToRevise);
@@ -48,7 +48,7 @@ export const Sep8Send = () => {
   }, [
     sep8Send.status,
     sep8Send.data.revisedTransaction.revisedTxXdr,
-    sep8Send.data.actionRequired.actionFields,
+    sep8Send.data.actionRequiredInfo.actionFields,
   ]);
 
   return (

--- a/src/components/Sep8Send/index.tsx
+++ b/src/components/Sep8Send/index.tsx
@@ -6,11 +6,15 @@ import { resetActiveAssetAction } from "ducks/activeAsset";
 import { resetSep8SendAction } from "ducks/sep8Send";
 import { useRedux } from "hooks/useRedux";
 import { ActionStatus } from "types/types.d";
+import { Sep8ActionRequiredForm } from "./Sep8ActionRequiredForm";
 
 export const Sep8Send = () => {
   const { sep8Send } = useRedux("sep8Send");
   const [approvalModalVisible, setApprovalModalVisible] = useState(false);
   const [reviewModalVisible, setReviewModalVisible] = useState(false);
+  const [actionRequiredModalVisible, setActionRequiredModalVisible] = useState(
+    false,
+  );
   const dispatch = useDispatch();
 
   const onClose = () => {
@@ -24,6 +28,7 @@ export const Sep8Send = () => {
     if (!sep8Send.status) {
       setReviewModalVisible(false);
       setApprovalModalVisible(false);
+      setActionRequiredModalVisible(false);
       return;
     }
 
@@ -34,15 +39,27 @@ export const Sep8Send = () => {
     const hasTxToRevise = Boolean(
       sep8Send.data.revisedTransaction.revisedTxXdr,
     );
-    setApprovalModalVisible(!hasTxToRevise);
+    const hasPendingActionRequired = Boolean(
+      sep8Send.data.actionRequired.actionFields.length,
+    );
+    setApprovalModalVisible(!hasTxToRevise && !hasPendingActionRequired);
     setReviewModalVisible(hasTxToRevise);
-  }, [sep8Send.status, sep8Send.data.revisedTransaction.revisedTxXdr]);
+    setActionRequiredModalVisible(hasPendingActionRequired && !hasTxToRevise);
+  }, [
+    sep8Send.status,
+    sep8Send.data.revisedTransaction.revisedTxXdr,
+    sep8Send.data.actionRequired.actionFields,
+  ]);
 
   return (
     <>
       {approvalModalVisible && <Sep8Approval onClose={onClose} />}
 
       {reviewModalVisible && <Sep8Review onClose={onClose} />}
+
+      {actionRequiredModalVisible && (
+        <Sep8ActionRequiredForm onClose={onClose} />
+      )}
     </>
   );
 };

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -157,7 +157,7 @@ const initialState: Sep8SendInitialState = {
       submittedTxXdr: "",
       revisedTxXdr: "",
     },
-    actionRequired: {
+    actionRequiredInfo: {
       actionFields: [],
       actionMethod: "",
       actionUrl: "",
@@ -196,8 +196,8 @@ const sep8SendSlice = createSlice({
       switch (action.payload.status) {
         case Sep8ApprovalStatus.ACTION_REQUIRED:
           state.status = ActionStatus.CAN_PROCEED;
-          if (action.payload.actionRequired) {
-            state.data.actionRequired = action.payload.actionRequired;
+          if (action.payload.actionRequiredInfo) {
+            state.data.actionRequiredInfo = action.payload.actionRequiredInfo;
           }
           break;
 

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -157,6 +157,12 @@ const initialState: Sep8SendInitialState = {
       submittedTxXdr: "",
       revisedTxXdr: "",
     },
+    actionRequired: {
+      actionFields: [],
+      actionMethod: "",
+      actionUrl: "",
+      message: "",
+    },
   },
   errorString: undefined,
   status: undefined,
@@ -188,6 +194,13 @@ const sep8SendSlice = createSlice({
     });
     builder.addCase(sep8ReviseTransactionAction.fulfilled, (state, action) => {
       switch (action.payload.status) {
+        case Sep8ApprovalStatus.ACTION_REQUIRED:
+          state.status = ActionStatus.CAN_PROCEED;
+          if (action.payload.actionRequired) {
+            state.data.actionRequired = action.payload.actionRequired;
+          }
+          break;
+
         case Sep8ApprovalStatus.PENDING:
           state.status = ActionStatus.NEEDS_INPUT;
           break;

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -117,30 +117,6 @@ export const sep8ReviseTransactionAction = createAsyncThunk<
   },
 );
 
-export const sep8SendActionRequiredParamsAction = createAsyncThunk<
-  Sep8ActionRequiredResult,
-  ActionRequiredParams,
-  { rejectValue: RejectMessage; state: RootState }
->(
-  "sep8Send/sep8SendActionRequiredParamsAction",
-  async (params, { rejectWithValue }) => {
-    const { actionFields, actionMethod, actionUrl } = params;
-
-    try {
-      const result = await sendActionRequiredFields({
-        actionFields,
-        actionMethod,
-        actionUrl,
-      });
-      return result;
-    } catch (error) {
-      const errorString = getErrorString(error);
-      log.error({ title: errorString });
-      return rejectWithValue({ errorString });
-    }
-  },
-);
-
 export const sep8SubmitRevisedTransactionAction = createAsyncThunk<
   Horizon.TransactionResponse,
   undefined,
@@ -160,6 +136,30 @@ export const sep8SubmitRevisedTransactionAction = createAsyncThunk<
         revisedTxXdr,
         isPubnet,
         secretKey,
+      });
+      return result;
+    } catch (error) {
+      const errorString = getErrorString(error);
+      log.error({ title: errorString });
+      return rejectWithValue({ errorString });
+    }
+  },
+);
+
+export const sep8SendActionRequiredParamsAction = createAsyncThunk<
+  Sep8ActionRequiredResult,
+  ActionRequiredParams,
+  { rejectValue: RejectMessage; state: RootState }
+>(
+  "sep8Send/sep8SendActionRequiredParamsAction",
+  async (params, { rejectWithValue }) => {
+    const { actionFields, actionMethod, actionUrl } = params;
+
+    try {
+      const result = await sendActionRequiredFields({
+        actionFields,
+        actionMethod,
+        actionUrl,
       });
       return result;
     } catch (error) {
@@ -220,27 +220,6 @@ const sep8SendSlice = createSlice({
       state.status = ActionStatus.ERROR;
     });
 
-    builder.addCase(
-      sep8SendActionRequiredParamsAction.pending,
-      (state = initialState) => {
-        state.status = ActionStatus.PENDING;
-      },
-    );
-    builder.addCase(
-      sep8SendActionRequiredParamsAction.fulfilled,
-      (state, action) => {
-        state.data = { ...state.data, actionRequiredResult: action.payload };
-        state.status = ActionStatus.SUCCESS;
-      },
-    );
-    builder.addCase(
-      sep8SendActionRequiredParamsAction.rejected,
-      (state, action) => {
-        state.errorString = action.payload?.errorString;
-        state.status = ActionStatus.ERROR;
-      },
-    );
-
     builder.addCase(sep8ReviseTransactionAction.pending, (state) => {
       state.errorString = undefined;
       state.status = ActionStatus.PENDING;
@@ -250,7 +229,10 @@ const sep8SendSlice = createSlice({
         case Sep8ApprovalStatus.ACTION_REQUIRED:
           state.status = ActionStatus.CAN_PROCEED;
           if (action.payload.actionRequiredInfo) {
-            state.data.actionRequiredInfo = action.payload.actionRequiredInfo;
+            state.data = {
+              ...state.data,
+              actionRequiredInfo: action.payload.actionRequiredInfo,
+            };
           }
           break;
 
@@ -262,7 +244,10 @@ const sep8SendSlice = createSlice({
         case Sep8ApprovalStatus.SUCCESS:
           state.status = ActionStatus.CAN_PROCEED;
           if (action.payload.revisedTransaction) {
-            state.data.revisedTransaction = action.payload.revisedTransaction;
+            state.data = {
+              ...state.data,
+              revisedTransaction: action.payload.revisedTransaction,
+            };
           }
           break;
 
@@ -285,6 +270,27 @@ const sep8SendSlice = createSlice({
     });
     builder.addCase(
       sep8SubmitRevisedTransactionAction.rejected,
+      (state, action) => {
+        state.errorString = action.payload?.errorString;
+        state.status = ActionStatus.ERROR;
+      },
+    );
+
+    builder.addCase(
+      sep8SendActionRequiredParamsAction.pending,
+      (state = initialState) => {
+        state.status = ActionStatus.PENDING;
+      },
+    );
+    builder.addCase(
+      sep8SendActionRequiredParamsAction.fulfilled,
+      (state, action) => {
+        state.data = { ...state.data, actionRequiredResult: action.payload };
+        state.status = ActionStatus.SUCCESS;
+      },
+    );
+    builder.addCase(
+      sep8SendActionRequiredParamsAction.rejected,
       (state, action) => {
         state.errorString = action.payload?.errorString;
         state.status = ActionStatus.ERROR;

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -209,10 +209,12 @@ const sep8SendSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder.addCase(initiateSep8SendAction.pending, (state = initialState) => {
+      state.errorString = undefined;
       state.status = ActionStatus.PENDING;
     });
     builder.addCase(initiateSep8SendAction.fulfilled, (state, action) => {
       state.data = { ...state.data, ...action.payload };
+      state.errorString = undefined;
       state.status = ActionStatus.CAN_PROCEED;
     });
     builder.addCase(initiateSep8SendAction.rejected, (state, action) => {
@@ -225,6 +227,8 @@ const sep8SendSlice = createSlice({
       state.status = ActionStatus.PENDING;
     });
     builder.addCase(sep8ReviseTransactionAction.fulfilled, (state, action) => {
+      state.errorString = undefined;
+
       switch (action.payload.status) {
         case Sep8ApprovalStatus.ACTION_REQUIRED:
           state.status = ActionStatus.CAN_PROCEED;
@@ -266,6 +270,7 @@ const sep8SendSlice = createSlice({
       state.status = ActionStatus.PENDING;
     });
     builder.addCase(sep8SubmitRevisedTransactionAction.fulfilled, (state) => {
+      state.errorString = undefined;
       state.status = ActionStatus.SUCCESS;
     });
     builder.addCase(
@@ -279,6 +284,7 @@ const sep8SendSlice = createSlice({
     builder.addCase(
       sep8SendActionRequiredParamsAction.pending,
       (state = initialState) => {
+        state.errorString = undefined;
         state.status = ActionStatus.PENDING;
       },
     );
@@ -286,6 +292,7 @@ const sep8SendSlice = createSlice({
       sep8SendActionRequiredParamsAction.fulfilled,
       (state, action) => {
         state.data = { ...state.data, actionRequiredResult: action.payload };
+        state.errorString = undefined;
         state.status = ActionStatus.SUCCESS;
       },
     );

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -172,6 +172,7 @@ export const sep8SendActionRequiredParamsAction = createAsyncThunk<
 
 const initialState: Sep8SendInitialState = {
   data: {
+    sep8Step: undefined,
     approvalCriteria: "",
     approvalServer: "",
     assetCode: "",

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -230,15 +230,27 @@ const sep8SendSlice = createSlice({
       state.errorString = undefined;
 
       switch (action.payload.status) {
-        case Sep8ApprovalStatus.ACTION_REQUIRED:
+        case Sep8ApprovalStatus.ACTION_REQUIRED: {
           state.status = ActionStatus.CAN_PROCEED;
-          if (action.payload.actionRequiredInfo) {
-            state.data = {
-              ...state.data,
-              actionRequiredInfo: action.payload.actionRequiredInfo,
-            };
+
+          const hasDataChanges =
+            !!action.payload.actionRequiredInfo ||
+            !!state.data.actionRequiredInfo;
+          if (!hasDataChanges) {
+            break;
           }
+
+          const actionRequiredInfo =
+            action.payload.actionRequiredInfo ?? state.data.actionRequiredInfo;
+          const revisedTransaction =
+            action.payload.revisedTransaction ?? state.data.revisedTransaction;
+          state.data = {
+            ...state.data,
+            actionRequiredInfo,
+            revisedTransaction,
+          };
           break;
+        }
 
         case Sep8ApprovalStatus.PENDING:
           state.status = ActionStatus.NEEDS_INPUT;

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -4,6 +4,7 @@ import { RootState } from "config/store";
 import { settingsSelector } from "ducks/settings";
 import { getErrorMessage } from "helpers/getErrorMessage";
 import { getErrorString } from "helpers/getErrorString";
+import { getSep8NextStepOnSuccess } from "helpers/getSep8NextStepOnSuccess";
 import { log } from "helpers/log";
 import { getToml } from "methods/getToml";
 import { revisePaymentTransaction } from "methods/sep8Send/revisePaymentTransaction";
@@ -16,7 +17,6 @@ import {
   Sep8ActionRequiredSentResult,
   Sep8ApprovalResponse,
   Sep8ApprovalStatus,
-  Sep8NextStepOnSuccess,
   Sep8PaymentTransactionParams,
   Sep8SendInitialState,
   Sep8Step,
@@ -224,7 +224,9 @@ const sep8SendSlice = createSlice({
       state.data = {
         ...state.data,
         ...action.payload,
-        sep8Step: Sep8NextStepOnSuccess({ currentStep: state.data.sep8Step }),
+        sep8Step: getSep8NextStepOnSuccess({
+          currentStep: state.data.sep8Step,
+        }),
       };
       state.status = ActionStatus.SUCCESS;
     });
@@ -270,7 +272,7 @@ const sep8SendSlice = createSlice({
       }
 
       state.status = ActionStatus.SUCCESS;
-      state.data.sep8Step = Sep8NextStepOnSuccess({
+      state.data.sep8Step = getSep8NextStepOnSuccess({
         approvalStatus: action.payload.status,
         currentStep: state.data.sep8Step,
       });
@@ -286,7 +288,7 @@ const sep8SendSlice = createSlice({
     });
     builder.addCase(sep8SubmitRevisedTransactionAction.fulfilled, (state) => {
       state.status = ActionStatus.SUCCESS;
-      state.data.sep8Step = Sep8NextStepOnSuccess({
+      state.data.sep8Step = getSep8NextStepOnSuccess({
         currentStep: state.data.sep8Step,
       });
     });
@@ -311,7 +313,7 @@ const sep8SendSlice = createSlice({
         state.data = {
           ...state.data,
           actionRequiredResult: action.payload,
-          sep8Step: Sep8NextStepOnSuccess({
+          sep8Step: getSep8NextStepOnSuccess({
             currentStep: state.data.sep8Step,
           }),
         };

--- a/src/helpers/getSep8NextStepOnSuccess.ts
+++ b/src/helpers/getSep8NextStepOnSuccess.ts
@@ -1,0 +1,36 @@
+import { Sep8ApprovalStatus, Sep8Step } from "types/types.d";
+
+/**
+ * Returns the next SEP-8 step to be displayed after the current step succeeds.
+ * @param {Sep8Step} currentStep the current SEP-8 step.
+ * @param {Sep8ApprovalStatus} [approvalStatus] the approval status returned from the SEP-8 server. This value will only be used if `currentStep === Sep8Step.STARTING`.
+ * @returns {Sep8Step} the next SEP-8 step for the application.
+ */
+export const getSep8NextStepOnSuccess = ({
+  currentStep,
+  approvalStatus,
+}: {
+  currentStep: Sep8Step;
+  approvalStatus?: Sep8ApprovalStatus;
+}): Sep8Step => {
+  const nextStepDict: { [key in Sep8Step]: Sep8Step } = {
+    [Sep8Step.DISABLED]: Sep8Step.STARTING,
+    [Sep8Step.STARTING]: (() => {
+      const approvalStatusDict: { [key in Sep8ApprovalStatus]: Sep8Step } = {
+        [Sep8ApprovalStatus.ACTION_REQUIRED]: Sep8Step.ACTION_REQUIRED,
+        [Sep8ApprovalStatus.PENDING]: Sep8Step.PENDING,
+        [Sep8ApprovalStatus.REVISED]: Sep8Step.TRANSACTION_REVISED,
+        [Sep8ApprovalStatus.SUCCESS]: Sep8Step.TRANSACTION_REVISED,
+        [Sep8ApprovalStatus.REJECTED]: currentStep,
+      };
+      return approvalStatusDict[approvalStatus!];
+    })(),
+    [Sep8Step.PENDING]: Sep8Step.DISABLED,
+    [Sep8Step.TRANSACTION_REVISED]: Sep8Step.COMPLETE,
+    [Sep8Step.ACTION_REQUIRED]: Sep8Step.SENT_ACTION_REQUIRED_FIELDS,
+    [Sep8Step.SENT_ACTION_REQUIRED_FIELDS]: Sep8Step.STARTING,
+    [Sep8Step.COMPLETE]: Sep8Step.DISABLED,
+  };
+
+  return nextStepDict[currentStep];
+};

--- a/src/methods/sep8Send/revisePaymentTransaction.ts
+++ b/src/methods/sep8Send/revisePaymentTransaction.ts
@@ -55,7 +55,7 @@ export const revisePaymentTransaction = async ({
     case Sep8ApprovalStatus.ACTION_REQUIRED:
       log.response({
         title: "Action Required",
-        body: "Additional information is needed before we can proceed",
+        body: "Additional information is needed before we can proceed.",
       });
       log.instruction({
         title: sep8ApprovalResultJson.message,

--- a/src/methods/sep8Send/revisePaymentTransaction.ts
+++ b/src/methods/sep8Send/revisePaymentTransaction.ts
@@ -80,7 +80,7 @@ export const revisePaymentTransaction = async ({
     case Sep8ApprovalStatus.PENDING: {
       const dateStr = new Date(sep8ApprovalResultJson.timeout).toLocaleString();
       log.response({
-        title: "Authorization pending",
+        title: "Authorization Pending",
         body: `The issuer could not determine whether to approve the transaction at this time. You can re-submit the same transaction on ${dateStr}.`,
       });
       if (sep8ApprovalResultJson.message) {

--- a/src/methods/sep8Send/revisePaymentTransaction.ts
+++ b/src/methods/sep8Send/revisePaymentTransaction.ts
@@ -63,7 +63,7 @@ export const revisePaymentTransaction = async ({
 
       return {
         status: Sep8ApprovalStatus.ACTION_REQUIRED,
-        actionRequired: {
+        actionRequiredInfo: {
           actionFields: sep8ApprovalResultJson.action_fields,
           actionMethod: sep8ApprovalResultJson.action_method,
           actionUrl: sep8ApprovalResultJson.action_url,

--- a/src/methods/sep8Send/revisePaymentTransaction.ts
+++ b/src/methods/sep8Send/revisePaymentTransaction.ts
@@ -52,6 +52,25 @@ export const revisePaymentTransaction = async ({
   // parse SEP-8 response
   const sep8ApprovalResultJson = await sep8ApprovalResult.json();
   switch (sep8ApprovalResultJson.status) {
+    case Sep8ApprovalStatus.ACTION_REQUIRED:
+      log.response({
+        title: "Action Required",
+        body: "Additional information is needed before we can proceed",
+      });
+      log.instruction({
+        title: sep8ApprovalResultJson.message,
+      });
+
+      return {
+        status: Sep8ApprovalStatus.ACTION_REQUIRED,
+        actionRequired: {
+          actionFields: sep8ApprovalResultJson.action_fields,
+          actionMethod: sep8ApprovalResultJson.action_method,
+          actionUrl: sep8ApprovalResultJson.action_url,
+          message: sep8ApprovalResultJson.message,
+        },
+      };
+
     case Sep8ApprovalStatus.PENDING: {
       const dateStr = new Date(sep8ApprovalResultJson.timeout).toLocaleString();
       log.response({

--- a/src/methods/sep8Send/revisePaymentTransaction.ts
+++ b/src/methods/sep8Send/revisePaymentTransaction.ts
@@ -69,6 +69,12 @@ export const revisePaymentTransaction = async ({
           actionUrl: sep8ApprovalResultJson.action_url,
           message: sep8ApprovalResultJson.message,
         },
+        revisedTransaction: {
+          amount: params.amount,
+          destination: params.destination,
+          submittedTxXdr,
+          revisedTxXdr: "",
+        },
       };
 
     case Sep8ApprovalStatus.PENDING: {

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -57,7 +57,7 @@ export const sendActionRequiredFields = async ({
   } else {
     log.instruction({
       title:
-        "The SEP-8 server received your information and may or may not approve it. Please submit a new SEP-8 payment to verify it went out correctly.",
+        "The SEP-8 server received your information, let's re-submit the SEP-8 payment again.",
     });
   }
 

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -1,17 +1,13 @@
 import { log } from "helpers/log";
-import { Sep8ActionRequiredResult } from "types/types.d";
+import { ActionRequiredParams, Sep8ActionRequiredResult } from "types/types.d";
 
 export const sendActionRequiredFields = async ({
   actionFields,
   actionMethod,
   actionUrl,
-}: {
-  actionFields: { [key: string]: string };
-  actionMethod: string;
-  actionUrl: string;
-}): Promise<Sep8ActionRequiredResult> => {
+}: ActionRequiredParams): Promise<Sep8ActionRequiredResult> => {
   log.request({
-    title: `Sending action required fields to SEP-8 server with ${actionMethod} ${actionUrl}`,
+    title: `Sending action required fields to SEP-8 server with [${actionMethod} ${actionUrl}]`,
     body: actionFields,
   });
   const sep8ActionRequiredResult = await fetch(actionUrl, {
@@ -46,13 +42,24 @@ export const sendActionRequiredFields = async ({
       break;
 
     default:
-      throw new Error(`Unexpected result: ${resultJson}`);
+      throw new Error(`Unexpected result: ${JSON.stringify(resultJson)}`);
   }
 
   log.response({
     title: "Action Required Response",
     body: resultJson,
   });
+
+  if (validatedResponse.message) {
+    log.instruction({
+      title: validatedResponse.message,
+    });
+  } else {
+    log.instruction({
+      title:
+        "The SEP-8 server received your information and may or may not approve it. Please submit a new SEP-8 payment to verify it went out correctly.",
+    });
+  }
 
   return validatedResponse;
 };

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -1,5 +1,6 @@
 import { log } from "helpers/log";
 import {
+  Sep8ActionRequiredResultType,
   Sep8ActionRequiredSendParams,
   Sep8ActionRequiredSentResult,
 } from "types/types.d";
@@ -24,18 +25,18 @@ export const sendActionRequiredFields = async ({
 
   let validatedResponse: Sep8ActionRequiredSentResult;
   switch (resultJson.result) {
-    case "no_further_action_required":
+    case Sep8ActionRequiredResultType.NO_FURTHER_ACTION_REQUIRED:
       validatedResponse = {
-        result: "no_further_action_required",
+        result: Sep8ActionRequiredResultType.NO_FURTHER_ACTION_REQUIRED,
       };
       break;
 
-    case "follow_next_url":
+    case Sep8ActionRequiredResultType.FOLLOW_NEXT_URL:
       if (!resultJson.next_url) {
         throw new Error(`Missing "next_url" parameter`);
       }
       validatedResponse = {
-        result: "follow_next_url",
+        result: Sep8ActionRequiredResultType.FOLLOW_NEXT_URL,
         nextUrl: resultJson.next_url,
       };
 

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -33,7 +33,7 @@ export const sendActionRequiredFields = async ({
 
     case Sep8ActionRequiredResultType.FOLLOW_NEXT_URL:
       if (!resultJson.next_url) {
-        throw new Error(`Missing "next_url" parameter`);
+        throw new Error(`Missing "next_url" parameter.`);
       }
       validatedResponse = {
         result: Sep8ActionRequiredResultType.FOLLOW_NEXT_URL,
@@ -61,7 +61,7 @@ export const sendActionRequiredFields = async ({
   } else {
     log.instruction({
       title:
-        "The SEP-8 server received your information, let's re-submit the SEP-8 payment again.",
+        "The SEP-8 server received your information, re-submit the SEP-8 payment.",
     });
   }
 

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -7,7 +7,7 @@ export const sendActionRequiredFields = async ({
   actionUrl,
 }: ActionRequiredParams): Promise<Sep8ActionRequiredResult> => {
   log.request({
-    title: `Sending action required fields to SEP-8 server with [${actionMethod} ${actionUrl}]`,
+    title: `Sending action required fields to SEP-8 server with \`${actionMethod} ${actionUrl}\``,
     body: actionFields,
   });
   const sep8ActionRequiredResult = await fetch(actionUrl, {

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -1,0 +1,58 @@
+import { log } from "helpers/log";
+import { Sep8ActionRequiredResult } from "types/types.d";
+
+export const sendActionRequiredFields = async ({
+  actionFields,
+  actionMethod,
+  actionUrl,
+}: {
+  actionFields: { [key: string]: string };
+  actionMethod: string;
+  actionUrl: string;
+}): Promise<Sep8ActionRequiredResult> => {
+  log.request({
+    title: `Sending action required fields to SEP-8 server with ${actionMethod} ${actionUrl}`,
+    body: actionFields,
+  });
+  const sep8ActionRequiredResult = await fetch(actionUrl, {
+    method: actionMethod,
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(actionFields),
+  });
+  const resultJson = await sep8ActionRequiredResult.json();
+
+  let validatedResponse: Sep8ActionRequiredResult;
+  switch (resultJson.result) {
+    case "no_further_action_required":
+      validatedResponse = {
+        result: "no_further_action_required",
+      };
+      break;
+
+    case "follow_next_url":
+      if (!resultJson.next_url) {
+        throw new Error(`Missing "next_url" parameter`);
+      }
+      validatedResponse = {
+        result: "follow_next_url",
+        nextUrl: resultJson.next_url,
+      };
+
+      if (resultJson.message) {
+        validatedResponse.message = resultJson.message;
+      }
+      break;
+
+    default:
+      throw new Error(`Unexpected result: ${resultJson}`);
+  }
+
+  log.response({
+    title: "Action Required Response",
+    body: resultJson,
+  });
+
+  return validatedResponse;
+};

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -1,11 +1,14 @@
 import { log } from "helpers/log";
-import { ActionRequiredParams, Sep8ActionRequiredResult } from "types/types.d";
+import {
+  Sep8ActionRequiredSendParams,
+  Sep8ActionRequiredSentResult,
+} from "types/types.d";
 
 export const sendActionRequiredFields = async ({
   actionFields,
   actionMethod,
   actionUrl,
-}: ActionRequiredParams): Promise<Sep8ActionRequiredResult> => {
+}: Sep8ActionRequiredSendParams): Promise<Sep8ActionRequiredSentResult> => {
   log.request({
     title: `Sending action required fields to SEP-8 server with \`${actionMethod} ${actionUrl}\``,
     body: actionFields,
@@ -19,7 +22,7 @@ export const sendActionRequiredFields = async ({
   });
   const resultJson = await sep8ActionRequiredResult.json();
 
-  let validatedResponse: Sep8ActionRequiredResult;
+  let validatedResponse: Sep8ActionRequiredSentResult;
   switch (resultJson.result) {
     case "no_further_action_required":
       validatedResponse = {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -344,11 +344,51 @@ export enum Sep8ApprovalStatus {
   SUCCESS = "success",
 }
 
-export interface Sep8PaymentTransactionParams extends PaymentTransactionParams {
-  approvalServer: string;
-  assetCode: string;
-  assetIssuer: string;
+export enum Sep8Step {
+  READY_TO_START = "ready_to_start",
+  TRANSACTION_REVISED = "transaction_revised",
+  COMPLETE = "complete",
+  ACTION_REQUIRED = "action_required",
+  SENT_ACTION_REQUIRED_PARAMS = "sent_action_required_params",
 }
+
+export const Sep8NextStepOnSuccess = ({
+  currentStep,
+  approvalStatus,
+}: {
+  currentStep: Sep8Step;
+  approvalStatus: Sep8ApprovalStatus;
+}) => {
+  switch (currentStep) {
+    case Sep8Step.READY_TO_START:
+      switch (approvalStatus) {
+        case Sep8ApprovalStatus.REVISED:
+        case Sep8ApprovalStatus.SUCCESS:
+          return Sep8Step.TRANSACTION_REVISED;
+
+        case Sep8ApprovalStatus.ACTION_REQUIRED:
+          return Sep8Step.ACTION_REQUIRED;
+
+        case Sep8ApprovalStatus.PENDING:
+          return undefined;
+
+        default:
+          return currentStep;
+      }
+
+    case Sep8Step.TRANSACTION_REVISED:
+      return Sep8Step.COMPLETE;
+
+    case Sep8Step.ACTION_REQUIRED:
+      return Sep8Step.SENT_ACTION_REQUIRED_PARAMS;
+
+    case Sep8Step.SENT_ACTION_REQUIRED_PARAMS:
+      return Sep8Step.READY_TO_START;
+
+    default:
+      return undefined;
+  }
+};
 
 export interface Sep8SendInitialState {
   data: {
@@ -378,6 +418,12 @@ export interface Sep8SendInitialState {
   };
   errorString?: string;
   status?: ActionStatus;
+}
+
+export interface Sep8PaymentTransactionParams extends PaymentTransactionParams {
+  approvalServer: string;
+  assetCode: string;
+  assetIssuer: string;
 }
 
 export interface Sep8RevisedTransactionInfo {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -382,14 +382,21 @@ export interface Sep8RevisedTransactionInfo {
   submittedTxXdr: string;
 }
 
+export interface Sep8ApprovalResponse {
+  status: Sep8ApprovalStatus;
+  revisedTransaction?: Sep8RevisedTransactionInfo;
+  actionRequired?: Sep8ActionRequiredInfo;
+}
+
 export interface Sep8ActionRequiredInfo {
   actionFields: string[];
   actionMethod: string;
   actionUrl: string;
   message: string;
 }
-export interface Sep8ApprovalResponse {
-  status: Sep8ApprovalStatus;
-  revisedTransaction?: Sep8RevisedTransactionInfo;
-  actionRequired?: Sep8ActionRequiredInfo;
+
+export interface Sep8ActionRequiredResult {
+  result: "no_further_action_required" | "follow_next_url";
+  nextUrl?: string;
+  message?: string;
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -345,7 +345,9 @@ export enum Sep8ApprovalStatus {
 }
 
 export enum Sep8Step {
-  READY_TO_START = "ready_to_start",
+  DISABLED = "disabled",
+  STARTING = "starting",
+  PENDING = "pending",
   TRANSACTION_REVISED = "transaction_revised",
   COMPLETE = "complete",
   ACTION_REQUIRED = "action_required",
@@ -357,10 +359,13 @@ export const Sep8NextStepOnSuccess = ({
   approvalStatus,
 }: {
   currentStep: Sep8Step;
-  approvalStatus: Sep8ApprovalStatus;
+  approvalStatus?: Sep8ApprovalStatus;
 }) => {
   switch (currentStep) {
-    case Sep8Step.READY_TO_START:
+    case Sep8Step.DISABLED:
+      return Sep8Step.STARTING;
+
+    case Sep8Step.STARTING:
       switch (approvalStatus) {
         case Sep8ApprovalStatus.REVISED:
         case Sep8ApprovalStatus.SUCCESS:
@@ -370,7 +375,7 @@ export const Sep8NextStepOnSuccess = ({
           return Sep8Step.ACTION_REQUIRED;
 
         case Sep8ApprovalStatus.PENDING:
-          return undefined;
+          return Sep8Step.PENDING;
 
         default:
           return currentStep;
@@ -383,15 +388,16 @@ export const Sep8NextStepOnSuccess = ({
       return Sep8Step.SENT_ACTION_REQUIRED_PARAMS;
 
     case Sep8Step.SENT_ACTION_REQUIRED_PARAMS:
-      return Sep8Step.READY_TO_START;
+      return Sep8Step.STARTING;
 
     default:
-      return undefined;
+      return Sep8Step.DISABLED;
   }
 };
 
 export interface Sep8SendInitialState {
   data: {
+    sep8Step: Sep8Step;
     approvalCriteria: string;
     approvalServer: string;
     assetCode: string;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -452,6 +452,11 @@ export interface Sep8ActionRequiredSendParams {
   actionUrl: string;
 }
 
+export enum Sep8ActionRequiredResultType {
+  FOLLOW_NEXT_URL = "follow_next_url",
+  NO_FURTHER_ACTION_REQUIRED = "no_further_action_required",
+}
+
 export interface Sep8ActionRequiredSentResult {
   result: string;
   nextUrl?: string;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -364,7 +364,7 @@ export interface Sep8SendInitialState {
       revisedTxXdr: string;
       submittedTxXdr: string;
     };
-    actionRequired: {
+    actionRequiredInfo: {
       actionFields: string[];
       actionMethod: string;
       actionUrl: string;
@@ -385,7 +385,7 @@ export interface Sep8RevisedTransactionInfo {
 export interface Sep8ApprovalResponse {
   status: Sep8ApprovalStatus;
   revisedTransaction?: Sep8RevisedTransactionInfo;
-  actionRequired?: Sep8ActionRequiredInfo;
+  actionRequiredInfo?: Sep8ActionRequiredInfo;
 }
 
 export interface Sep8ActionRequiredInfo {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -370,6 +370,11 @@ export interface Sep8SendInitialState {
       actionUrl: string;
       message: string;
     };
+    actionRequiredResult: {
+      result: string;
+      nextUrl?: string;
+      message?: string;
+    };
   };
   errorString?: string;
   status?: ActionStatus;
@@ -386,6 +391,7 @@ export interface Sep8ApprovalResponse {
   status: Sep8ApprovalStatus;
   revisedTransaction?: Sep8RevisedTransactionInfo;
   actionRequiredInfo?: Sep8ActionRequiredInfo;
+  actionRequiredResult?: Sep8ActionRequiredResult;
 }
 
 export interface Sep8ActionRequiredInfo {
@@ -395,8 +401,14 @@ export interface Sep8ActionRequiredInfo {
   message: string;
 }
 
+export interface ActionRequiredParams {
+  actionFields: { [key: string]: string };
+  actionMethod: string;
+  actionUrl: string;
+}
+
 export interface Sep8ActionRequiredResult {
-  result: "no_further_action_required" | "follow_next_url";
+  result: string;
   nextUrl?: string;
   message?: string;
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -364,6 +364,12 @@ export interface Sep8SendInitialState {
       revisedTxXdr: string;
       submittedTxXdr: string;
     };
+    actionRequired: {
+      actionFields: string[];
+      actionMethod: string;
+      actionUrl: string;
+      message: string;
+    };
   };
   errorString?: string;
   status?: ActionStatus;
@@ -376,7 +382,14 @@ export interface Sep8RevisedTransactionInfo {
   submittedTxXdr: string;
 }
 
+export interface Sep8ActionRequiredInfo {
+  actionFields: string[];
+  actionMethod: string;
+  actionUrl: string;
+  message: string;
+}
 export interface Sep8ApprovalResponse {
   status: Sep8ApprovalStatus;
   revisedTransaction?: Sep8RevisedTransactionInfo;
+  actionRequired?: Sep8ActionRequiredInfo;
 }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -360,41 +360,6 @@ export interface Sep8PaymentTransactionParams extends PaymentTransactionParams {
   assetIssuer: string;
 }
 
-/**
- * Returns the next SEP-8 step to be displayed after the current step succeeds.
- * @param {Sep8Step} currentStep the current SEP-8 step.
- * @param {Sep8ApprovalStatus} [approvalStatus] the approval status returned from the SEP-8 server. This value will only be used if `currentStep === Sep8Step.STARTING`.
- * @returns {Sep8Step} the next SEP-8 step for the application.
- */
-export const Sep8NextStepOnSuccess = ({
-  currentStep,
-  approvalStatus,
-}: {
-  currentStep: Sep8Step;
-  approvalStatus?: Sep8ApprovalStatus;
-}): Sep8Step => {
-  const nextStepDict: { [key: Sep8Step]: Sep8Step } = {
-    [Sep8Step.DISABLED]: Sep8Step.STARTING,
-    [Sep8Step.STARTING]: (() => {
-      const approvalStatusDict: { [key: Sep8ApprovalStatus]: Sep8Step } = {
-        [Sep8ApprovalStatus.ACTION_REQUIRED]: Sep8Step.ACTION_REQUIRED,
-        [Sep8ApprovalStatus.PENDING]: Sep8Step.PENDING,
-        [Sep8ApprovalStatus.REVISED]: Sep8Step.TRANSACTION_REVISED,
-        [Sep8ApprovalStatus.SUCCESS]: Sep8Step.TRANSACTION_REVISED,
-        [Sep8ApprovalStatus.REJECTED]: currentStep,
-      };
-      return approvalStatusDict[approvalStatus];
-    })(),
-    [Sep8Step.PENDING]: Sep8Step.DISABLED,
-    [Sep8Step.TRANSACTION_REVISED]: Sep8Step.COMPLETE,
-    [Sep8Step.ACTION_REQUIRED]: Sep8Step.SENT_ACTION_REQUIRED_FIELDS,
-    [Sep8Step.SENT_ACTION_REQUIRED_FIELDS]: Sep8Step.STARTING,
-    [Sep8Step.COMPLETE]: Sep8Step.DISABLED,
-  };
-
-  return nextStepDict[currentStep];
-};
-
 export interface Sep8SendInitialState {
   data: {
     sep8Step: Sep8Step;


### PR DESCRIPTION
### What

Support SEP-8 "Action Required" flow.

Closes #113 

### Future Work

The action fields received in the action required responses are all being handled as strings for now. I'll update this behavior to accept different kinds of inputs in the future, since the [SEP-9] field types can include "string", "country code", "phone number", date", "number" or "binary".

[SEP-9]: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0009.md

### Screenshot

https://user-images.githubusercontent.com/1952597/119165154-958bd600-ba33-11eb-9639-3d014c8003d4.mov

### How to test

Use the jenkins preview link with `/account?secretKey=SBQZPYFQNQD4B7MP7PC3NKCMS5G5LD6PVO7BUYC34M4BBFN6KCXSKSVD` and send a small payment to `GBID36ML6VVNPIF6SQATQW5QIBREQAVEHQIUMWDLQCSVIYX2IJGK4KPP`.

#### KYC Approval Criteria

* Emails starting with "x" will get rejected
* Emails not starting with "x" will get approved.

If you need to repeat your tests you might need to delete the KYC already stored in the server with:
```curl
curl -X DELETE https://sep8-server.dev.stellar.org/kyc-status/GASA5HCKMDAPLB6NIV7ADDA6YMTAQ2555TXKMS7FSVO44TJXHEGXLICZ
```