### PR TITLE
Disable support to SEP-8 payments

### DIFF
--- a/src/components/BalanceRow.tsx
+++ b/src/components/BalanceRow.tsx
@@ -89,24 +89,6 @@ export const BalanceRow = ({
         )}
       </div>
 
-      {supportedActions?.sep8 && (
-        <div className="RegulatedInfo">
-          <span>Regulated</span>
-          <InfoButtonWithTooltip>
-            {
-              "Payments with regulated assets need to be approved by the asset issuer. For more information please refer to "
-            }
-            <TextLink
-              href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md"
-              isExternal
-            >
-              SEP-8
-            </TextLink>
-            "."
-          </InfoButtonWithTooltip>
-        </div>
-      )}
-
       <div className="BalanceCell BalanceActions">
         {children && <div className="CustomCell">{children}</div>}
 
@@ -119,14 +101,8 @@ export const BalanceRow = ({
               value={selectValue}
             >
               <option value="">Select action</option>
-              {!isUntrusted && !asset.supportedActions?.sep8 && (
+              {!isUntrusted && (
                 <option value={AssetActionId.SEND_PAYMENT}>Send payment</option>
-              )}
-
-              {asset.supportedActions?.sep8 && (
-                <option value={AssetActionId.SEP8_SEND_PAYMENT}>
-                  SEP-8 Send
-                </option>
               )}
 
               {supportedActions?.sep24 && (

--- a/src/helpers/getErrorString.ts
+++ b/src/helpers/getErrorString.ts
@@ -21,6 +21,7 @@ export const TX_ERROR_TEXT: ErrorTextObject = {
   buy_no_issuer: "The issuer of that token doesn’t exist.",
   op_offer_not_found: "We couldn’t find that offer.",
   op_low_reserve: "That offer would take you below the minimum XLM reserve.",
+  op_not_authorized: "This operation was not authorized.",
   tx_bad_auth: "Something went wrong while signing a transaction.",
   tx_bad_seq:
     "The app has gotten out of sync with the network. Please try again later.",


### PR DESCRIPTION
### What

Disable support to SEP-8 payments.

### Why

We're temporarily disabling the SEP-8 payment support so we can prepare our release setup properly. SEP-8 support will be re-added in version `1.2.0`.

### How to test

Use the jenkins preview link with `/account?secretKey=SBQZPYFQNQD4B7MP7PC3NKCMS5G5LD6PVO7BUYC34M4BBFN6KCXSKSVD`. The Payments with `MYASSET` will be handled as if they were regular payments and thus will fail with `op_not_authorized`.