### PR TITLE
Revert "Disable support to SEP-8 payments (#166)"

### DIFF
--- a/src/components/BalanceRow.tsx
+++ b/src/components/BalanceRow.tsx
@@ -89,6 +89,24 @@ export const BalanceRow = ({
         )}
       </div>
 
+      {supportedActions?.sep8 && (
+        <div className="RegulatedInfo">
+          <span>Regulated</span>
+          <InfoButtonWithTooltip>
+            {
+              "Payments with regulated assets need to be approved by the asset issuer. For more information please refer to "
+            }
+            <TextLink
+              href="https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md"
+              isExternal
+            >
+              SEP-8
+            </TextLink>
+            "."
+          </InfoButtonWithTooltip>
+        </div>
+      )}
+
       <div className="BalanceCell BalanceActions">
         {children && <div className="CustomCell">{children}</div>}
 
@@ -101,8 +119,14 @@ export const BalanceRow = ({
               value={selectValue}
             >
               <option value="">Select action</option>
-              {!isUntrusted && (
+              {!isUntrusted && !asset.supportedActions?.sep8 && (
                 <option value={AssetActionId.SEND_PAYMENT}>Send payment</option>
+              )}
+
+              {asset.supportedActions?.sep8 && (
+                <option value={AssetActionId.SEP8_SEND_PAYMENT}>
+                  SEP-8 Send
+                </option>
               )}
 
               {supportedActions?.sep24 && (

--- a/src/helpers/getErrorString.ts
+++ b/src/helpers/getErrorString.ts
@@ -21,6 +21,7 @@ export const TX_ERROR_TEXT: ErrorTextObject = {
   buy_no_issuer: "The issuer of that token doesn’t exist.",
   op_offer_not_found: "We couldn’t find that offer.",
   op_low_reserve: "That offer would take you below the minimum XLM reserve.",
+  op_not_authorized: "This operation was not authorized.",
   tx_bad_auth: "Something went wrong while signing a transaction.",
   tx_bad_seq:
     "The app has gotten out of sync with the network. Please try again later.",

--- a/src/helpers/getErrorString.ts
+++ b/src/helpers/getErrorString.ts
@@ -21,7 +21,8 @@ export const TX_ERROR_TEXT: ErrorTextObject = {
   buy_no_issuer: "The issuer of that token doesn’t exist.",
   op_offer_not_found: "We couldn’t find that offer.",
   op_low_reserve: "That offer would take you below the minimum XLM reserve.",
-  op_not_authorized: "This operation was not authorized.",
+  op_not_authorized:
+    "This operation was not authorized, please make sure the asset you used complies with the Regulated Assets protocol (SEP-8).",
   tx_bad_auth: "Something went wrong while signing a transaction.",
   tx_bad_seq:
     "The app has gotten out of sync with the network. Please try again later.",

--- a/src/helpers/getErrorString.ts
+++ b/src/helpers/getErrorString.ts
@@ -21,7 +21,6 @@ export const TX_ERROR_TEXT: ErrorTextObject = {
   buy_no_issuer: "The issuer of that token doesn’t exist.",
   op_offer_not_found: "We couldn’t find that offer.",
   op_low_reserve: "That offer would take you below the minimum XLM reserve.",
-  op_not_authorized: "This operation was not authorized.",
   tx_bad_auth: "Something went wrong while signing a transaction.",
   tx_bad_seq:
     "The app has gotten out of sync with the network. Please try again later.",


### PR DESCRIPTION
### What

Revert "Disable support to SEP-8 payments (#166)": 15ca900.

Additionally, includes human readable string for Horizon's message `op_not_authorized`.

### Why

We had temporarily removed it in PR #166 to better organize our releasing setup.