### PR TITLE
Sentry: do not trace any origin (localhost CORS issue)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,12 @@ if (process.env.REACT_APP_SENTRY_KEY) {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_KEY,
     release: `demo-wallet@${process.env.npm_package_version}`,
-    integrations: [new Integrations.BrowserTracing()],
+    integrations: [
+      new Integrations.BrowserTracing({
+        // not attaching sentry-trace to any XHR/fetch outgoing requests
+        tracingOrigins: [],
+      }),
+    ],
     tracesSampleRate: 1.0,
   });
 }


### PR DESCRIPTION
Potential fix to https://github.com/stellar/stellar-demo-wallet/issues/178. 🤞 
The issue seems to be with [`tracingOrigins`](https://docs.sentry.io/platforms/javascript/performance/instrumentation/automatic-instrumentation/#tracingorigins) attaching `sentry-trace` headers to `localhost` calls by default.