### PR TITLE
SEP-8: update UX for the Action Required flow

### DIFF
--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -4,6 +4,7 @@ import { Button, Input, Loader } from "@stellar/design-system";
 import { Heading2 } from "components/Heading";
 import { Modal } from "components/Modal";
 import {
+  initiateSep8SendAction,
   sep8ReviseTransactionAction,
   sep8SendActionRequiredFieldsAction,
 } from "ducks/sep8Send";
@@ -45,9 +46,22 @@ export const Sep8ActionRequiredForm = ({
 
       if (nextUrl && result === Sep8ActionRequiredResultType.FOLLOW_NEXT_URL) {
         window.open(nextUrl, "_blank");
+
+        if (account.data) {
+          dispatch(
+            initiateSep8SendAction({
+              assetCode: sep8Send.data.assetCode,
+              assetIssuer: sep8Send.data.assetIssuer,
+              homeDomain: sep8Send.data.homeDomain,
+            }),
+          );
+        }
       }
 
-      if (account.data) {
+      if (
+        account.data &&
+        result === Sep8ActionRequiredResultType.NO_FURTHER_ACTION_REQUIRED
+      ) {
         const params = {
           destination: sep8Send.data.revisedTransaction.destination,
           isDestinationFunded: true,
@@ -68,12 +82,13 @@ export const Sep8ActionRequiredForm = ({
     dispatch,
     nextUrl,
     result,
+    sep8Send.data.approvalServer,
     sep8Send.data.assetCode,
     sep8Send.data.assetIssuer,
-    sep8Send.data.sep8Step,
-    sep8Send.data.approvalServer,
+    sep8Send.data.homeDomain,
     sep8Send.data.revisedTransaction.amount,
     sep8Send.data.revisedTransaction.destination,
+    sep8Send.data.sep8Step,
   ]);
 
   const handleSubmitActionRequiredFields = () => {

--- a/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
+++ b/src/components/Sep8Send/Sep8ActionRequiredForm.tsx
@@ -4,7 +4,7 @@ import { Button, Input, Loader } from "@stellar/design-system";
 import { Heading2 } from "components/Heading";
 import { Modal } from "components/Modal";
 import {
-  initiateSep8SendAction,
+  sep8ReviseTransactionAction,
   sep8SendActionRequiredFieldsAction,
 } from "ducks/sep8Send";
 import { Sep9Field, Sep9FieldType } from "helpers/Sep9Fields";
@@ -48,13 +48,17 @@ export const Sep8ActionRequiredForm = ({
       }
 
       if (account.data) {
-        dispatch(
-          initiateSep8SendAction({
-            assetCode: sep8Send.data.assetCode,
-            assetIssuer: sep8Send.data.assetIssuer,
-            homeDomain: sep8Send.data.homeDomain,
-          }),
-        );
+        const params = {
+          destination: sep8Send.data.revisedTransaction.destination,
+          isDestinationFunded: true,
+          amount: sep8Send.data.revisedTransaction.amount,
+          assetCode: sep8Send.data.assetCode,
+          assetIssuer: sep8Send.data.assetIssuer,
+          publicKey: account.data?.id,
+          approvalServer: sep8Send.data.approvalServer,
+        };
+
+        dispatch(sep8ReviseTransactionAction(params));
       }
     }
   }, [
@@ -66,8 +70,10 @@ export const Sep8ActionRequiredForm = ({
     result,
     sep8Send.data.assetCode,
     sep8Send.data.assetIssuer,
-    sep8Send.data.homeDomain,
     sep8Send.data.sep8Step,
+    sep8Send.data.approvalServer,
+    sep8Send.data.revisedTransaction.amount,
+    sep8Send.data.revisedTransaction.destination,
   ]);
 
   const handleSubmitActionRequiredFields = () => {

--- a/src/components/Sep8Send/Sep8Review.tsx
+++ b/src/components/Sep8Send/Sep8Review.tsx
@@ -9,11 +9,7 @@ import { fetchAccountAction } from "ducks/account";
 import { sep8SubmitRevisedTransactionAction } from "ducks/sep8Send";
 import { getNetworkConfig } from "helpers/getNetworkConfig";
 import { useRedux } from "hooks/useRedux";
-import {
-  ActionStatus,
-  Sep8ActionRequiredResultType,
-  Sep8Step,
-} from "types/types.d";
+import { ActionStatus, Sep8Step } from "types/types.d";
 
 export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
   const { account, sep8Send, settings } = useRedux(
@@ -78,8 +74,7 @@ export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
       <div className="ModalBody">
         <div className="ModalMessage">
           <p>
-            {sep8Send.data.actionRequiredResult.result ===
-              Sep8ActionRequiredResultType.NO_FURTHER_ACTION_REQUIRED &&
+            {sep8Send.data.actionRequiredResult.result &&
               "KYC has been approved. "}
             Please review the updated operations before submitting your SEP-8
             payment.

--- a/src/components/Sep8Send/Sep8Review.tsx
+++ b/src/components/Sep8Send/Sep8Review.tsx
@@ -9,7 +9,11 @@ import { fetchAccountAction } from "ducks/account";
 import { sep8SubmitRevisedTransactionAction } from "ducks/sep8Send";
 import { getNetworkConfig } from "helpers/getNetworkConfig";
 import { useRedux } from "hooks/useRedux";
-import { ActionStatus, Sep8Step } from "types/types.d";
+import {
+  ActionStatus,
+  Sep8ActionRequiredResultType,
+  Sep8Step,
+} from "types/types.d";
 
 export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
   const { account, sep8Send, settings } = useRedux(
@@ -74,6 +78,9 @@ export const Sep8Review = ({ onClose }: { onClose: () => void }) => {
       <div className="ModalBody">
         <div className="ModalMessage">
           <p>
+            {sep8Send.data.actionRequiredResult.result ===
+              Sep8ActionRequiredResultType.NO_FURTHER_ACTION_REQUIRED &&
+              "KYC has been approved. "}
             Please review the updated operations before submitting your SEP-8
             payment.
           </p>

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -275,7 +275,7 @@ const sep8SendSlice = createSlice({
       state.data.sep8Step = getSep8NextStepOnSuccess({
         approvalStatus: action.payload.status,
         currentStep: state.data.sep8Step,
-        didUndergoKYC: !!state.data.actionRequiredResult.result,
+        didUndergoKyc: !!state.data.actionRequiredResult.result,
       });
     });
     builder.addCase(sep8ReviseTransactionAction.rejected, (state, action) => {

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -275,6 +275,7 @@ const sep8SendSlice = createSlice({
       state.data.sep8Step = getSep8NextStepOnSuccess({
         approvalStatus: action.payload.status,
         currentStep: state.data.sep8Step,
+        didUndergoKYC: !!state.data.actionRequiredResult.result,
       });
     });
     builder.addCase(sep8ReviseTransactionAction.rejected, (state, action) => {

--- a/src/ducks/sep8Send.ts
+++ b/src/ducks/sep8Send.ts
@@ -275,7 +275,7 @@ const sep8SendSlice = createSlice({
       state.data.sep8Step = getSep8NextStepOnSuccess({
         approvalStatus: action.payload.status,
         currentStep: state.data.sep8Step,
-        didUndergoKyc: !!state.data.actionRequiredResult.result,
+        didUndergoKyc: Boolean(state.data.actionRequiredResult.result),
       });
     });
     builder.addCase(sep8ReviseTransactionAction.rejected, (state, action) => {

--- a/src/helpers/getSep8NextStepOnSuccess.ts
+++ b/src/helpers/getSep8NextStepOnSuccess.ts
@@ -9,11 +9,11 @@ import { Sep8ApprovalStatus, Sep8Step } from "types/types.d";
 export const getSep8NextStepOnSuccess = ({
   currentStep,
   approvalStatus,
-  didUndergoKYC,
+  didUndergoKyc,
 }: {
   currentStep: Sep8Step;
   approvalStatus?: Sep8ApprovalStatus;
-  didUndergoKYC?: boolean;
+  didUndergoKyc?: boolean;
 }): Sep8Step => {
   const nextStepDict: { [key in Sep8Step]: Sep8Step } = {
     [Sep8Step.DISABLED]: Sep8Step.STARTING,
@@ -24,7 +24,7 @@ export const getSep8NextStepOnSuccess = ({
     [Sep8Step.PENDING]: Sep8Step.DISABLED,
     [Sep8Step.TRANSACTION_REVISED]: Sep8Step.COMPLETE,
     [Sep8Step.ACTION_REQUIRED]: Sep8Step.SENT_ACTION_REQUIRED_FIELDS,
-    [Sep8Step.SENT_ACTION_REQUIRED_FIELDS]: didUndergoKYC
+    [Sep8Step.SENT_ACTION_REQUIRED_FIELDS]: didUndergoKyc
       ? nextStepAfterApprovalServer({
           currentStep,
           approvalStatus,

--- a/src/helpers/getSep8NextStepOnSuccess.ts
+++ b/src/helpers/getSep8NextStepOnSuccess.ts
@@ -9,9 +9,11 @@ import { Sep8ApprovalStatus, Sep8Step } from "types/types.d";
 export const getSep8NextStepOnSuccess = ({
   currentStep,
   approvalStatus,
+  didUndergoKYC,
 }: {
   currentStep: Sep8Step;
   approvalStatus?: Sep8ApprovalStatus;
+  didUndergoKYC?: boolean;
 }): Sep8Step => {
   const nextStepDict: { [key in Sep8Step]: Sep8Step } = {
     [Sep8Step.DISABLED]: Sep8Step.STARTING,
@@ -22,10 +24,12 @@ export const getSep8NextStepOnSuccess = ({
     [Sep8Step.PENDING]: Sep8Step.DISABLED,
     [Sep8Step.TRANSACTION_REVISED]: Sep8Step.COMPLETE,
     [Sep8Step.ACTION_REQUIRED]: Sep8Step.SENT_ACTION_REQUIRED_FIELDS,
-    [Sep8Step.SENT_ACTION_REQUIRED_FIELDS]: nextStepAfterApprovalServer({
-      currentStep,
-      approvalStatus,
-    }),
+    [Sep8Step.SENT_ACTION_REQUIRED_FIELDS]: didUndergoKYC
+      ? nextStepAfterApprovalServer({
+          currentStep,
+          approvalStatus,
+        })
+      : Sep8Step.STARTING,
     [Sep8Step.COMPLETE]: Sep8Step.DISABLED,
   };
 

--- a/src/helpers/getSep8NextStepOnSuccess.ts
+++ b/src/helpers/getSep8NextStepOnSuccess.ts
@@ -33,8 +33,6 @@ export const getSep8NextStepOnSuccess = ({
     [Sep8Step.COMPLETE]: Sep8Step.DISABLED,
   };
 
-  console.log(currentStep, "->", nextStepDict[currentStep]);
-
   return nextStepDict[currentStep];
 };
 

--- a/src/helpers/getSep8NextStepOnSuccess.ts
+++ b/src/helpers/getSep8NextStepOnSuccess.ts
@@ -15,22 +15,44 @@ export const getSep8NextStepOnSuccess = ({
 }): Sep8Step => {
   const nextStepDict: { [key in Sep8Step]: Sep8Step } = {
     [Sep8Step.DISABLED]: Sep8Step.STARTING,
-    [Sep8Step.STARTING]: (() => {
-      const approvalStatusDict: { [key in Sep8ApprovalStatus]: Sep8Step } = {
-        [Sep8ApprovalStatus.ACTION_REQUIRED]: Sep8Step.ACTION_REQUIRED,
-        [Sep8ApprovalStatus.PENDING]: Sep8Step.PENDING,
-        [Sep8ApprovalStatus.REVISED]: Sep8Step.TRANSACTION_REVISED,
-        [Sep8ApprovalStatus.SUCCESS]: Sep8Step.TRANSACTION_REVISED,
-        [Sep8ApprovalStatus.REJECTED]: currentStep,
-      };
-      return approvalStatusDict[approvalStatus!];
-    })(),
+    [Sep8Step.STARTING]: nextStepAfterApprovalServer({
+      currentStep,
+      approvalStatus,
+    }),
     [Sep8Step.PENDING]: Sep8Step.DISABLED,
     [Sep8Step.TRANSACTION_REVISED]: Sep8Step.COMPLETE,
     [Sep8Step.ACTION_REQUIRED]: Sep8Step.SENT_ACTION_REQUIRED_FIELDS,
-    [Sep8Step.SENT_ACTION_REQUIRED_FIELDS]: Sep8Step.STARTING,
+    [Sep8Step.SENT_ACTION_REQUIRED_FIELDS]: nextStepAfterApprovalServer({
+      currentStep,
+      approvalStatus,
+    }),
     [Sep8Step.COMPLETE]: Sep8Step.DISABLED,
   };
 
+  console.log(currentStep, "->", nextStepDict[currentStep]);
+
   return nextStepDict[currentStep];
+};
+
+/**
+ * Returns the next SEP-8 step to be displayed after the current step succeeds, based solely on the respone comming from the SEP-8 approval server.
+ * @param {Sep8Step} currentStep the current SEP-8 step.
+ * @param {Sep8ApprovalStatus} [approvalStatus] the approval status returned from the SEP-8 server. This value will only be used if `currentStep === Sep8Step.STARTING`.
+ * @returns {Sep8Step} the next SEP-8 step for the application.
+ */
+const nextStepAfterApprovalServer = ({
+  currentStep,
+  approvalStatus,
+}: {
+  currentStep: Sep8Step;
+  approvalStatus?: Sep8ApprovalStatus;
+}) => {
+  const approvalStatusDict: { [key in Sep8ApprovalStatus]: Sep8Step } = {
+    [Sep8ApprovalStatus.ACTION_REQUIRED]: Sep8Step.ACTION_REQUIRED,
+    [Sep8ApprovalStatus.PENDING]: Sep8Step.PENDING,
+    [Sep8ApprovalStatus.REVISED]: Sep8Step.TRANSACTION_REVISED,
+    [Sep8ApprovalStatus.SUCCESS]: Sep8Step.TRANSACTION_REVISED,
+    [Sep8ApprovalStatus.REJECTED]: currentStep,
+  };
+  return approvalStatusDict[approvalStatus!];
 };

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -78,7 +78,7 @@ export const sendActionRequiredFields = async ({
   log.instruction({
     title:
       validatedResponse.message ??
-      "The SEP-8 server received your information, re-submit the SEP-8 payment.",
+      "The SEP-8 server received your information, re-submitting the SEP-8 payment...",
   });
 
   return validatedResponse;

--- a/src/methods/sep8Send/sendActionRequiredFields.ts
+++ b/src/methods/sep8Send/sendActionRequiredFields.ts
@@ -75,10 +75,14 @@ export const sendActionRequiredFields = async ({
     body: resultJson,
   });
 
+  const defaultCompletionMessage =
+    resultJson.result ===
+    Sep8ActionRequiredResultType.NO_FURTHER_ACTION_REQUIRED
+      ? "The SEP-8 server received your information, re-submitting the SEP-8 payment..."
+      : "The SEP-8 server received your information, re-submit the SEP-8 payment.";
+
   log.instruction({
-    title:
-      validatedResponse.message ??
-      "The SEP-8 server received your information, re-submitting the SEP-8 payment...",
+    title: validatedResponse.message ?? defaultCompletionMessage,
   });
 
   return validatedResponse;


### PR DESCRIPTION
### Changes

* After getting the KYC approved, send the user straight to the “review & submit” modal.
* Update the “Review & Submit” modal text to “`KYC has been approved.` Please review the updated operations before submitting your SEP-8 payment.”
* Update the log message when resubmitting payment automatically.

### Preview


https://user-images.githubusercontent.com/1952597/124181606-1ce55400-da8c-11eb-8fb3-3c8adb917f13.mov

