### PR TITLE
SEP-10 auth: use home_domain param

### DIFF
--- a/src/methods/sep10Auth/start.ts
+++ b/src/methods/sep10Auth/start.ts
@@ -12,7 +12,7 @@ export const start = async ({
   publicKey: string;
   homeDomain: string;
 }) => {
-  const params = { account: publicKey, homeDomain };
+  const params = { account: publicKey, home_domain: homeDomain };
 
   log.instruction({
     title:


### PR DESCRIPTION
Using `home_domain` param instead of `homeDomain`.

![image](https://user-images.githubusercontent.com/7346473/127510223-dc02bf75-0311-46a0-99a7-2071df5a75f9.png)
