### PR TITLE
SEP-24 withdraw: show result codes in error message

### DIFF
--- a/packages/demo-wallet-client/src/ducks/sep24WithdrawAsset.ts
+++ b/packages/demo-wallet-client/src/ducks/sep24WithdrawAsset.ts
@@ -144,12 +144,15 @@ export const withdrawAssetAction = createAsyncThunk<
       return {
         currentStatus,
       };
-    } catch (error) {
+    } catch (error: any) {
       const errorMessage = getErrorMessage(error);
+      const resultCodes = error?.response?.data?.extras?.result_codes;
 
       log.error({
         title: "SEP-24 withdrawal failed",
-        body: errorMessage,
+        body: `${errorMessage} ${
+          resultCodes ? JSON.stringify(resultCodes) : ""
+        }`,
       });
 
       return rejectWithValue({


### PR DESCRIPTION
A quick fix to add result codes to error message in SEP-24 withdrawal.

![image](https://github.com/stellar/stellar-demo-wallet/assets/7346473/cc34f6c6-e5ab-480d-8ff5-b8270364fc5c)
