### PR TITLE
Refactor asset data fetching and handling

### DIFF
--- a/packages/demo-wallet-client/src/components/Assets.tsx
+++ b/packages/demo-wallet-client/src/components/Assets.tsx
@@ -104,16 +104,35 @@ export const Assets = ({
     CONFIRM_ACTION = "CONFIRM_ACTION",
   }
 
+  const updateAssetOverride = useCallback(
+    (assetString: string) => {
+      const hasOverride = assetOverrides.data.find(
+        (a) => a.assetString === assetString,
+      );
+
+      if (hasOverride) {
+        dispatch(
+          updateAssetOverrideAction({
+            assetString: assetString,
+            updatedProperties: { isUntrusted: false },
+          }),
+        );
+      }
+    },
+    [assetOverrides.data, dispatch],
+  );
+
   const handleRemoveUntrustedAsset = useCallback(
     (removeAsset?: string) => {
       if (removeAsset) {
         navigate(
           searchParam.remove(SearchParams.UNTRUSTED_ASSETS, removeAsset),
         );
+        updateAssetOverride(removeAsset);
         dispatch(removeUntrustedAssetAction(removeAsset));
       }
     },
-    [dispatch, navigate],
+    [dispatch, navigate, updateAssetOverride],
   );
 
   const handleRefreshAccount = useCallback(() => {
@@ -232,12 +251,7 @@ export const Assets = ({
         ),
       );
       dispatch(removeUntrustedAssetAction(trustAsset.assetString));
-      dispatch(
-        updateAssetOverrideAction({
-          assetString: trustAsset.assetString,
-          updatedProperties: { isUntrusted: false },
-        }),
-      );
+      updateAssetOverride(trustAsset.assetString);
       dispatch(resetTrustAssetAction());
       handleRefreshAccount();
     }
@@ -250,6 +264,7 @@ export const Assets = ({
     trustAsset.status,
     trustAsset.assetString,
     handleRefreshAccount,
+    updateAssetOverride,
     setActiveAssetStatusAndToastMessage,
     dispatch,
     navigate,

--- a/packages/demo-wallet-client/src/components/Assets.tsx
+++ b/packages/demo-wallet-client/src/components/Assets.tsx
@@ -32,6 +32,7 @@ import {
 import {
   addAssetOverridesAction,
   resetAssetOverridesStatusAction,
+  updateAssetOverrideAction,
 } from "ducks/assetOverrides";
 import { resetClaimAssetAction } from "ducks/claimAsset";
 import { fetchClaimableBalancesAction } from "ducks/claimableBalances";
@@ -231,6 +232,12 @@ export const Assets = ({
         ),
       );
       dispatch(removeUntrustedAssetAction(trustAsset.assetString));
+      dispatch(
+        updateAssetOverrideAction({
+          assetString: trustAsset.assetString,
+          updatedProperties: { isUntrusted: false },
+        }),
+      );
       dispatch(resetTrustAssetAction());
       handleRefreshAccount();
     }
@@ -247,6 +254,18 @@ export const Assets = ({
     dispatch,
     navigate,
   ]);
+
+  // Remove untrusted asset
+  useEffect(() => {
+    if (
+      untrustedAssets.status === ActionStatus.SUCCESS ||
+      untrustedAssets.status === ActionStatus.ERROR
+    ) {
+      dispatch(getAllAssetsAction());
+      dispatch(resetActiveAssetAction());
+      dispatch(resetUntrustedAssetStatusAction());
+    }
+  }, [untrustedAssets.status, dispatch]);
 
   // SEP-6 Deposit asset
   useEffect(() => {
@@ -383,18 +402,6 @@ export const Assets = ({
       message: "SEP-31 send in progress",
     });
   }, [sep31Send.status, setActiveAssetStatusAndToastMessage]);
-
-  // Remove untrusted asset
-  useEffect(() => {
-    if (
-      untrustedAssets.status === ActionStatus.SUCCESS ||
-      untrustedAssets.status === ActionStatus.ERROR
-    ) {
-      dispatch(getAllAssetsAction());
-      dispatch(resetUntrustedAssetStatusAction());
-      dispatch(resetActiveAssetAction());
-    }
-  }, [untrustedAssets.status, dispatch]);
 
   return (
     <>

--- a/packages/demo-wallet-client/src/components/SettingsHandler.tsx
+++ b/packages/demo-wallet-client/src/components/SettingsHandler.tsx
@@ -30,6 +30,33 @@ export const SettingsHandler = ({
     SearchParams.CLAIMABLE_BALANCE_SUPPORTED,
   );
 
+  // Asset overrides
+  useEffect(() => {
+    dispatch(
+      updateSettingsAction({
+        [SearchParams.ASSET_OVERRIDES]: assetOverridesParam || "",
+      }),
+    );
+  }, [assetOverridesParam, dispatch]);
+
+  // Untrusted assets
+  useEffect(() => {
+    const cleanedAssets = untrustedAssetsParam
+      ?.split(",")
+      .reduce(
+        (unique: string[], item: string) =>
+          unique.includes(item) ? unique : [...unique, item],
+        [],
+      )
+      .join(",");
+
+    dispatch(
+      updateSettingsAction({
+        [SearchParams.UNTRUSTED_ASSETS]: cleanedAssets || "",
+      }),
+    );
+  }, [untrustedAssetsParam, dispatch]);
+
   // Set secret key param (secretKey=[SECRET_KEY]) and fetch account info
   // This will handle both: secret key submitted on Demo Wallet and directly
   // from the URL
@@ -62,33 +89,6 @@ export const SettingsHandler = ({
       }
     }
   }, [secretKeyParam, dispatch]);
-
-  // Untrusted assets
-  useEffect(() => {
-    const cleanedAssets = untrustedAssetsParam
-      ?.split(",")
-      .reduce(
-        (unique: string[], item: string) =>
-          unique.includes(item) ? unique : [...unique, item],
-        [],
-      )
-      .join(",");
-
-    dispatch(
-      updateSettingsAction({
-        [SearchParams.UNTRUSTED_ASSETS]: cleanedAssets || "",
-      }),
-    );
-  }, [untrustedAssetsParam, dispatch]);
-
-  // Asset overrides
-  useEffect(() => {
-    dispatch(
-      updateSettingsAction({
-        [SearchParams.ASSET_OVERRIDES]: assetOverridesParam || "",
-      }),
-    );
-  }, [assetOverridesParam, dispatch]);
 
   // Claimabable balance supported
   useEffect(() => {

--- a/packages/demo-wallet-client/src/components/UntrustedBalance.tsx
+++ b/packages/demo-wallet-client/src/components/UntrustedBalance.tsx
@@ -58,7 +58,8 @@ export const UntrustedBalance = ({
     }
 
     dispatch(addUntrustedAssetAction(settings.untrustedAssets));
-  }, [settings.untrustedAssets, dispatch]);
+    // Update when asset overrides change as well
+  }, [settings.untrustedAssets, settings.assetOverrides, dispatch]);
 
   const handleTrustAsset = (asset: Asset) => {
     const { assetString, assetCode, assetIssuer } = asset;

--- a/packages/demo-wallet-client/src/ducks/account.ts
+++ b/packages/demo-wallet-client/src/ducks/account.ts
@@ -4,17 +4,11 @@ import { getCatchError } from "@stellar/frontend-helpers";
 import { Keypair } from "stellar-sdk";
 
 import { RootState } from "config/store";
-import { getAssetData } from "demo-wallet-shared/build/helpers/getAssetData";
 import { getErrorMessage } from "demo-wallet-shared/build/helpers/getErrorMessage";
 import { getErrorString } from "demo-wallet-shared/build/helpers/getErrorString";
 import { getNetworkConfig } from "demo-wallet-shared/build/helpers/getNetworkConfig";
 import { log } from "demo-wallet-shared/build/helpers/log";
-import {
-  ActionStatus,
-  Asset,
-  RejectMessage,
-  AccountInitialState,
-} from "types/types";
+import { ActionStatus, RejectMessage, AccountInitialState } from "types/types";
 
 interface UnfundedAccount extends Types.AccountDetails {
   id: string;
@@ -27,7 +21,6 @@ interface AccountKeyPair {
 
 interface AccountActionBaseResponse {
   data: Types.AccountDetails | UnfundedAccount;
-  assets: Asset[];
   isUnfunded: boolean;
 }
 
@@ -55,7 +48,6 @@ export const fetchAccountAction = createAsyncThunk<
     });
 
     let stellarAccount: Types.AccountDetails | null = null;
-    let assets: Asset[] = [];
     let isUnfunded = false;
 
     log.request({
@@ -65,10 +57,6 @@ export const fetchAccountAction = createAsyncThunk<
 
     try {
       stellarAccount = await dataProvider.fetchAccountDetails();
-      assets = await getAssetData({
-        balances: stellarAccount.balances,
-        networkUrl: networkConfig.url,
-      });
     } catch (e) {
       const error: ResponseError = getCatchError(e);
 
@@ -97,7 +85,7 @@ export const fetchAccountAction = createAsyncThunk<
       body: stellarAccount,
     });
 
-    return { data: stellarAccount, assets, isUnfunded, secretKey };
+    return { data: stellarAccount, isUnfunded, secretKey };
   },
 );
 
@@ -143,17 +131,13 @@ export const fundTestnetAccount = createAsyncThunk<
   try {
     await fetch(`https://friendbot.stellar.org?addr=${publicKey}`);
     const stellarAccount = await dataProvider.fetchAccountDetails();
-    const assets = await getAssetData({
-      balances: stellarAccount.balances,
-      networkUrl: networkConfig.url,
-    });
 
     log.response({
       title: "The friendbot funded account",
       body: stellarAccount,
     });
 
-    return { data: stellarAccount, assets, isUnfunded: false };
+    return { data: stellarAccount, isUnfunded: false };
   } catch (error) {
     log.error({
       title: "The friendbot funding of the account failed",
@@ -169,7 +153,6 @@ export const fundTestnetAccount = createAsyncThunk<
 
 const initialState: AccountInitialState = {
   data: null,
-  assets: [],
   errorString: undefined,
   isAuthenticated: false,
   isUnfunded: false,
@@ -192,7 +175,6 @@ const accountSlice = createSlice({
     });
     builder.addCase(fetchAccountAction.fulfilled, (state, action) => {
       state.data = action.payload.data;
-      state.assets = action.payload.assets;
       state.isAuthenticated = Boolean(action.payload.data);
       state.isUnfunded = action.payload.isUnfunded;
       state.secretKey = action.payload.secretKey;
@@ -220,7 +202,6 @@ const accountSlice = createSlice({
     });
     builder.addCase(fundTestnetAccount.fulfilled, (state, action) => {
       state.data = action.payload.data;
-      state.assets = action.payload.assets;
       state.isUnfunded = action.payload.isUnfunded;
       state.status = ActionStatus.SUCCESS;
     });

--- a/packages/demo-wallet-client/src/ducks/allAssets.ts
+++ b/packages/demo-wallet-client/src/ducks/allAssets.ts
@@ -1,10 +1,16 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import { Types } from "@stellar/wallet-sdk";
+
 import { RootState } from "config/store";
 import { accountSelector } from "ducks/account";
 import { assetOverridesSelector } from "ducks/assetOverrides";
 import { untrustedAssetsSelector } from "ducks/untrustedAssets";
+import { settingsSelector } from "ducks/settings";
 import { getErrorMessage } from "demo-wallet-shared/build/helpers/getErrorMessage";
 import { log } from "demo-wallet-shared/build/helpers/log";
+import { getAssetData } from "demo-wallet-shared/build/helpers/getAssetData";
+import { searchKeyPairStringToArray } from "demo-wallet-shared/build/helpers/searchKeyPairStringToArray";
+import { getNetworkConfig } from "demo-wallet-shared/build/helpers/getNetworkConfig";
 import {
   ActionStatus,
   RejectMessage,
@@ -15,43 +21,62 @@ import {
 
 type IncludeAssetOverridesProps = {
   assets: Asset[];
+  balances?: Types.BalanceMap;
   assetCategory: AssetCategory;
   assetOverrides: Asset[];
 };
 
 const includeAssetOverrides = ({
   assets,
+  balances,
   assetCategory,
   assetOverrides,
-}: IncludeAssetOverridesProps) =>
-  assets.reduce((result: Asset[], asset) => {
-    const overrideAsset = assetOverrides.find(
-      (ao) => ao.assetString === asset.assetString,
-    );
-    const updatedAsset = overrideAsset
-      ? {
-          ...overrideAsset,
-          category: assetCategory,
-          isUntrusted: asset.isUntrusted,
-          isOverride: true,
-          total: asset.total,
-        }
-      : { ...asset, category: assetCategory };
+}: IncludeAssetOverridesProps) => {
+  const isUntrusted = assetCategory === AssetCategory.UNTRUSTED;
+  const overrides = assetOverrides.filter((o) => o.isUntrusted === isUntrusted);
 
-    return [...result, updatedAsset];
-  }, []);
+  return [...assets, ...overrides].map((a) => ({
+    ...a,
+    category: assetCategory,
+    // Use balance from account balances
+    total: balances?.[a.assetString]?.available?.toString() || a.total || "0",
+  }));
+};
 
+// All assets (from account balances, assetOverrides, and untrustedAssets) are
+// aggregated here to display on the UI.
+
+// Assets with overrides will be removed from untrustedAssets and will be skipped
+// in account balances to avoid making API calls with on-chain home domain. All
+// assets with overrides will be added to assetOverrides in store and picked from
+// there in this action.
 export const getAllAssetsAction = createAsyncThunk<
   Asset[],
   undefined,
   { rejectValue: RejectMessage; state: RootState }
->("allAssets/getAllAssetsAction", (_, { rejectWithValue, getState }) => {
-  const { assets } = accountSelector(getState());
+>("allAssets/getAllAssetsAction", async (_, { rejectWithValue, getState }) => {
+  const networkConfig = getNetworkConfig();
+
+  const { data } = accountSelector(getState());
   const { data: untrustedAssets } = untrustedAssetsSelector(getState());
   const { data: assetOverrides } = assetOverridesSelector(getState());
+  const { assetOverrides: asssetOverrideSetting } = settingsSelector(
+    getState(),
+  );
+
+  const overrideIds = searchKeyPairStringToArray(asssetOverrideSetting).map(
+    (a) => a.assetString,
+  );
+
+  const assets = await getAssetData({
+    balances: data?.balances,
+    networkUrl: networkConfig.url,
+    overrideIds,
+  });
 
   const trusted = includeAssetOverrides({
     assets,
+    balances: data?.balances,
     assetCategory: AssetCategory.TRUSTED,
     assetOverrides,
   });
@@ -63,7 +88,21 @@ export const getAllAssetsAction = createAsyncThunk<
   });
 
   try {
-    return [...trusted, ...untrusted];
+    // Sort to make sure the order doesn't change when adding/removing overrides
+    return [...trusted, ...untrusted].sort((a, b) => {
+      const assetA = a.assetString;
+      const assetB = b.assetString;
+
+      if (assetA < assetB) {
+        return -1;
+      }
+
+      if (assetA > assetB) {
+        return 1;
+      }
+
+      return 0;
+    });
   } catch (error) {
     const errorMessage = getErrorMessage(error);
     log.error({ title: errorMessage });

--- a/packages/demo-wallet-client/src/ducks/assetOverrides.ts
+++ b/packages/demo-wallet-client/src/ducks/assetOverrides.ts
@@ -62,15 +62,17 @@ const assetOverridesSlice = createSlice({
     },
     resetAssetOverridesAction: () => initialState,
     updateAssetOverrideAction: (state, action) => {
-      const updated = state.data.map((a) => {
-        if (a.assetString === action.payload.assetString) {
-          return { ...a, ...action.payload.updatedProperties };
-        }
+      if (state.data.length) {
+        const updated = state.data.map((a) => {
+          if (a.assetString === action.payload.assetString) {
+            return { ...a, ...action.payload.updatedProperties };
+          }
 
-        return a;
-      });
+          return a;
+        });
 
-      state.data = updated;
+        state.data = updated;
+      }
     },
   },
   extraReducers: (builder) => {

--- a/packages/demo-wallet-client/src/ducks/assetOverrides.ts
+++ b/packages/demo-wallet-client/src/ducks/assetOverrides.ts
@@ -1,5 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { RootState } from "config/store";
+import { settingsSelector } from "ducks/settings";
 import { getErrorMessage } from "demo-wallet-shared/build/helpers/getErrorMessage";
 import { getAssetOverridesData } from "demo-wallet-shared/build/helpers/getAssetOverridesData";
 import { getNetworkConfig } from "demo-wallet-shared/build/helpers/getNetworkConfig";
@@ -18,13 +19,21 @@ export const addAssetOverridesAction = createAsyncThunk<
   { rejectValue: RejectMessage; state: RootState }
 >(
   "assetOverrides/addAssetOverridesAction",
-  async (assetOverridesString, { rejectWithValue }) => {
+  async (assetOverridesString, { rejectWithValue, getState }) => {
+    const { untrustedAssets: untrustedAssetsSetting } = settingsSelector(
+      getState(),
+    );
+
     try {
       const assetOverrides = searchKeyPairStringToArray(assetOverridesString);
+      const untrustedAssets = searchKeyPairStringToArray(
+        untrustedAssetsSetting,
+      ).map((u) => u.assetString);
 
       const response = await getAssetOverridesData({
         assetOverrides,
         networkUrl: getNetworkConfig().url,
+        untrustedAssets,
       });
 
       return response;
@@ -52,6 +61,17 @@ const assetOverridesSlice = createSlice({
       state.status = undefined;
     },
     resetAssetOverridesAction: () => initialState,
+    updateAssetOverrideAction: (state, action) => {
+      const updated = state.data.map((a) => {
+        if (a.assetString === action.payload.assetString) {
+          return { ...a, ...action.payload.updatedProperties };
+        }
+
+        return a;
+      });
+
+      state.data = updated;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(addAssetOverridesAction.pending, (state = initialState) => {
@@ -72,5 +92,8 @@ export const assetOverridesSelector = (state: RootState) =>
   state.assetOverrides;
 
 export const { reducer } = assetOverridesSlice;
-export const { resetAssetOverridesStatusAction, resetAssetOverridesAction } =
-  assetOverridesSlice.actions;
+export const {
+  resetAssetOverridesStatusAction,
+  resetAssetOverridesAction,
+  updateAssetOverrideAction,
+} = assetOverridesSlice.actions;

--- a/packages/demo-wallet-client/src/ducks/untrustedAssets.ts
+++ b/packages/demo-wallet-client/src/ducks/untrustedAssets.ts
@@ -2,10 +2,12 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { getCatchError } from "@stellar/frontend-helpers";
 import { RootState } from "config/store";
 import { accountSelector } from "ducks/account";
+import { settingsSelector } from "ducks/settings";
 import { getErrorMessage } from "demo-wallet-shared/build/helpers/getErrorMessage";
 import { getUntrustedAssetData } from "demo-wallet-shared/build/helpers/getUntrustedAssetData";
 import { getNetworkConfig } from "demo-wallet-shared/build/helpers/getNetworkConfig";
 import { log } from "demo-wallet-shared/build/helpers/log";
+import { searchKeyPairStringToArray } from "demo-wallet-shared/build/helpers/searchKeyPairStringToArray";
 import {
   ActionStatus,
   RejectMessage,
@@ -42,12 +44,17 @@ export const addUntrustedAssetAction = createAsyncThunk<
   async (assetsString, { rejectWithValue, getState }) => {
     const { data: accountData } = accountSelector(getState());
     const { data } = untrustedAssetsSelector(getState());
+    const { assetOverrides } = settingsSelector(getState());
 
     try {
+      const overrideIds = searchKeyPairStringToArray(assetOverrides).map(
+        (a) => a.assetString,
+      );
+
       const assetsListToAdd = removeExistingAssets({
         assetsString,
         untrustedAssets: data,
-      });
+      }).filter((a) => !overrideIds.includes(a));
 
       if (!assetsListToAdd.length) {
         return [];

--- a/packages/demo-wallet-client/src/types/types.ts
+++ b/packages/demo-wallet-client/src/types/types.ts
@@ -81,7 +81,6 @@ export interface AssetSupportedActions {
 
 export interface AccountInitialState {
   data: Types.AccountDetails | null;
-  assets: Asset[];
   errorString?: string;
   isAuthenticated: boolean;
   isUnfunded: boolean;

--- a/packages/demo-wallet-shared/helpers/getAssetData.ts
+++ b/packages/demo-wallet-shared/helpers/getAssetData.ts
@@ -1,4 +1,5 @@
 import { Types } from "@stellar/wallet-sdk";
+import { omit } from "lodash";
 import { getAssetSettingsFromToml } from "./getAssetSettingsFromToml";
 import { normalizeAssetProps } from "./normalizeAssetProps";
 import { Asset } from "../types/types";
@@ -6,15 +7,17 @@ import { Asset } from "../types/types";
 export const getAssetData = async ({
   balances,
   networkUrl,
+  overrideIds,
 }: {
-  balances: Types.BalanceMap;
+  balances: Types.BalanceMap | undefined;
   networkUrl: string;
+  overrideIds: string[];
 }) => {
-  const allAssets = Object.entries(balances);
+  const allAssets = Object.entries(omit(balances || {}, overrideIds));
   const assets: Asset[] = [];
 
   if (!allAssets?.length) {
-    return assets;
+    return [];
   }
 
   // eslint-disable-next-line @typescript-eslint/prefer-for-of
@@ -29,7 +32,7 @@ export const getAssetData = async ({
 
     assets.push(
       normalizeAssetProps({
-        source: data,
+        source: data as Types.AssetBalance,
         homeDomain,
         supportedActions,
       }),

--- a/packages/demo-wallet-shared/helpers/getAssetOverridesData.ts
+++ b/packages/demo-wallet-shared/helpers/getAssetOverridesData.ts
@@ -8,11 +8,13 @@ import { Asset, AssetType, SearchParamAsset } from "../types/types";
 type GetAssetOverridesDataProps = {
   assetOverrides: SearchParamAsset[];
   networkUrl: string;
+  untrustedAssets: string[];
 };
 
 export const getAssetOverridesData = async ({
   assetOverrides,
   networkUrl,
+  untrustedAssets,
 }: GetAssetOverridesDataProps) => {
   if (!assetOverrides.length) {
     return [];
@@ -60,6 +62,8 @@ export const getAssetOverridesData = async ({
         ? AssetType.NATIVE
         : assetResponse?.records[0]?.asset_type,
       homeDomain,
+      isOverride: true,
+      isUntrusted: untrustedAssets.includes(assetString),
       supportedActions,
     });
 

--- a/packages/demo-wallet-shared/helpers/normalizeAssetProps.ts
+++ b/packages/demo-wallet-shared/helpers/normalizeAssetProps.ts
@@ -11,6 +11,7 @@ interface NormalizeAssetProps {
   homeDomain?: string;
   supportedActions?: AssetSupportedActions | AnyObject;
   isUntrusted?: boolean;
+  isOverride?: boolean;
   assetCode?: string;
   assetIssuer?: string;
   assetType?: string;
@@ -21,6 +22,7 @@ export const normalizeAssetProps = ({
   homeDomain,
   supportedActions,
   isUntrusted = false,
+  isOverride = false,
   assetCode = "",
   assetIssuer = "",
   assetType = "",
@@ -50,6 +52,7 @@ export const normalizeAssetProps = ({
     homeDomain,
     supportedActions,
     isUntrusted,
+    isOverride,
     source,
   };
 };


### PR DESCRIPTION
Refactored to fetch asset data "on demand" instead of always fetching on-chain data, which resulted in unnecessary calls for assets with home domain override.

## Test cases
### Unfunded account

- [x]  Add untrusted asset
- [x]  Add untrusted asset with override
- [x]  Remove override from untrusted asset
- [x]  Create account with untrusted asset
- [x]  Create account with untrusted asset with override

### Funded account

- [x]  Add untrusted asset
- [x]  Add untrusted asset with override
- [x]  Remove override from untrusted asset
- [x]  Add override to untrusted asset
- [x]  Add trustline with untrusted asset
- [x]  Add trustline with untrusted asset with override
- [x]  Add override to trusted asset
- [x]  Remove override from trusted asset
- [x] SEP-6 deposit with trusted asset shows correct balance
- [x] SEP-6 deposit with untrusted asset shows correct balance
- [x] SEP-24 deposit with trusted asset and override shows correct balance
- [x] SEP-24 deposit with untrusted asset and override shows correct balance