### PR TITLE
Fix XLM withdraw failure

### DIFF
--- a/packages/demo-wallet-shared/methods/sep24/pollWithdrawUntilComplete.ts
+++ b/packages/demo-wallet-shared/methods/sep24/pollWithdrawUntilComplete.ts
@@ -12,17 +12,17 @@ import { AnyObject, TransactionStatus } from "../../types/types";
 import { getNetworkConfig } from "../../helpers/getNetworkConfig";
 
 export const pollWithdrawUntilComplete = async ({
-  secretKey,
-  popup,
-  transactionId,
-  token,
-  sep24TransferServerUrl,
-  networkPassphrase,
-  networkUrl,
-  assetCode,
-  assetIssuer,
-  sep9Fields,
-}: {
+                                                  secretKey,
+                                                  popup,
+                                                  transactionId,
+                                                  token,
+                                                  sep24TransferServerUrl,
+                                                  networkPassphrase,
+                                                  networkUrl,
+                                                  assetCode,
+                                                  assetIssuer,
+                                                  sep9Fields,
+                                                }: {
   secretKey: string;
   popup: any;
   transactionId: string;
@@ -95,6 +95,13 @@ export const pollWithdrawUntilComplete = async ({
             body: sequence,
           });
 
+          let paymentAsset = null;
+          if (assetCode === "XLM") {
+            paymentAsset = Asset.native();
+          } else {
+            paymentAsset = new Asset(assetCode, assetIssuer);
+          }
+
           const account = new Account(keypair.publicKey(), sequence);
           const txn = new TransactionBuilder(account, {
             fee: getNetworkConfig().baseFee,
@@ -103,8 +110,8 @@ export const pollWithdrawUntilComplete = async ({
             .addOperation(
               Operation.payment({
                 destination:
-                  transactionJson.transaction.withdraw_anchor_account,
-                asset: new Asset(assetCode, assetIssuer),
+                transactionJson.transaction.withdraw_anchor_account,
+                asset: paymentAsset,
                 amount: transactionJson.transaction.amount_in,
               }),
             )

--- a/packages/demo-wallet-shared/methods/sep24/pollWithdrawUntilComplete.ts
+++ b/packages/demo-wallet-shared/methods/sep24/pollWithdrawUntilComplete.ts
@@ -12,17 +12,17 @@ import { AnyObject, TransactionStatus } from "../../types/types";
 import { getNetworkConfig } from "../../helpers/getNetworkConfig";
 
 export const pollWithdrawUntilComplete = async ({
-                                                  secretKey,
-                                                  popup,
-                                                  transactionId,
-                                                  token,
-                                                  sep24TransferServerUrl,
-                                                  networkPassphrase,
-                                                  networkUrl,
-                                                  assetCode,
-                                                  assetIssuer,
-                                                  sep9Fields,
-                                                }: {
+  secretKey,
+  popup,
+  transactionId,
+  token,
+  sep24TransferServerUrl,
+  networkPassphrase,
+  networkUrl,
+  assetCode,
+  assetIssuer,
+  sep9Fields,
+}: {
   secretKey: string;
   popup: any;
   transactionId: string;

--- a/packages/demo-wallet-shared/methods/sep24/pollWithdrawUntilComplete.ts
+++ b/packages/demo-wallet-shared/methods/sep24/pollWithdrawUntilComplete.ts
@@ -95,13 +95,7 @@ export const pollWithdrawUntilComplete = async ({
             body: sequence,
           });
 
-          let paymentAsset = null;
-          if (assetCode === "XLM") {
-            paymentAsset = Asset.native();
-          } else {
-            paymentAsset = new Asset(assetCode, assetIssuer);
-          }
-
+          const paymentAsset = assetCode === "XLM" ? Asset.native() : new Asset(assetCode, assetIssuer);
           const account = new Account(keypair.publicKey(), sequence);
           const txn = new TransactionBuilder(account, {
             fee: getNetworkConfig().baseFee,

--- a/packages/demo-wallet-shared/methods/sep6/pollWithdrawUntilComplete.ts
+++ b/packages/demo-wallet-shared/methods/sep6/pollWithdrawUntilComplete.ts
@@ -93,6 +93,7 @@ export const pollWithdrawUntilComplete = async ({
             body: sequence,
           });
 
+          const paymentAsset = assetCode === "XLM" ? Asset.native() : new Asset(assetCode, assetIssuer);
           const account = new Account(keypair.publicKey(), sequence);
           const txn = new TransactionBuilder(account, {
             fee: getNetworkConfig().baseFee,
@@ -102,7 +103,7 @@ export const pollWithdrawUntilComplete = async ({
               Operation.payment({
                 destination:
                   transactionJson.transaction.withdraw_anchor_account,
-                asset: new Asset(assetCode, assetIssuer),
+                asset: paymentAsset,
                 amount,
               }),
             )


### PR DESCRIPTION
Fix the XLM withdraw submission failure when polling the transaction status.

`new Asset("XLM", "native")` is no longer valid and should be replaced with `Asset.native()`.