### PR TITLE
[Fix] Fix the incorrect interchange of `destinationAssetCode` and `sourceAsset`

### DIFF
--- a/packages/demo-wallet-client/src/ducks/sep6Deposit.ts
+++ b/packages/demo-wallet-client/src/ducks/sep6Deposit.ts
@@ -387,8 +387,8 @@ export const initSep6DepositFlowWithQuoteAction = createAsyncThunk<
 
       const depositResponse = (await programmaticDepositExchangeFlow({
         amount,
-        sourceAsset,
         destinationAssetCode,
+        sourceAsset,
         quoteId,
         publicKey,
         transferServerUrl,


### PR DESCRIPTION
This is causing reference server sep6 deposit flow referencing wrong asset in `amountIn` `amountOut` and `amountExpected`