### PR TITLE
Fix Webpack 5 warning for 'vm' module 

### DIFF
--- a/packages/demo-wallet-client/webpack.common.js
+++ b/packages/demo-wallet-client/webpack.common.js
@@ -131,6 +131,7 @@ module.exports = {
       os: require.resolve("os-browserify"),
       url: require.resolve("url"),
       buffer: require.resolve("buffer/"),
+      vm: false
     },
   },
   plugins: [


### PR DESCRIPTION
This PR fixes a Webpack 5 warning related to the missing Node.js core module 'vm', which is referenced indirectly by the `asn1.js` package through `crypto-browserify`.

Since the `vm` module is not needed in a browser environment, this change explicitly disables the fallback for it

```
[webpack-dev-server] WARNING in ../../node_modules/asn1.js/lib/asn1/api.js 21:12-42
Module not found: Error: Can't resolve 'vm' in '/Users/jiahuihu/Documents/GitHub/stellar-demo-wallet/node_modules/asn1.js/lib/asn1'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "vm": require.resolve("vm-browserify") }'
	- install 'vm-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "vm": false }
```