### PR TITLE
[ANCHOR-1023] Implement Contract Account Info and Redirection

### DIFF
--- a/packages/demo-wallet-client/src/App.scss
+++ b/packages/demo-wallet-client/src/App.scss
@@ -148,6 +148,12 @@
       margin-bottom: 1rem;
     }
   }
+
+  &__section {
+    & + & {
+      margin-top: 2rem;
+    }
+  }
 }
 
 .LoadingBlock {

--- a/packages/demo-wallet-client/src/App.scss
+++ b/packages/demo-wallet-client/src/App.scss
@@ -197,7 +197,6 @@
 
   .AccountInfo {
     display: table;
-    max-width: 276px;
 
     &:first-child {
       margin-bottom: 1rem;

--- a/packages/demo-wallet-client/src/components/ContractAccountInfo.tsx
+++ b/packages/demo-wallet-client/src/components/ContractAccountInfo.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import {
+  Heading2,
+  TextLink,
+  Layout,
+  CopyText,
+} from "@stellar/design-system";
+
+import { Json } from "components/Json";
+import { shortenStellarKey } from "demo-wallet-shared/build/helpers/shortenStellarKey";
+import { ActionStatus } from "../types/types";
+import { useDispatch } from "react-redux";
+import {
+  fetchContractAccountAction,
+} from "../ducks/contractAccount";
+import { AppDispatch } from "../config/store";
+import { useRedux } from "../hooks/useRedux";
+
+export const ContractAccountInfo = () => {
+  const { contractAccount } = useRedux("contractAccount")
+  const [isContractDetailsVisible, setIsContractDetailsVisible] = useState(false);
+
+  const dispatch: AppDispatch = useDispatch();
+
+  const contractId = contractAccount.data?.contract;
+  if (!contractId) {
+    return null;
+  }
+
+  const handleRefreshAccount = () => {
+    if (contractAccount.status !== ActionStatus.PENDING) {
+      dispatch(fetchContractAccountAction(contractId));
+    }
+  };
+
+  return (
+    <Layout.Inset>
+      <div className="Account">
+        {/* Contract keys */}
+        <div className="AccountInfo">
+          <div className="AccountInfoRow">
+            <div className="AccountInfoCell AccountLabel">Contract ID</div>
+            <div className="AccountInfoCell ContractIdCell">
+              {shortenStellarKey(contractId)}
+            </div>
+            <div className="AccountInfoCell CopyButton">
+              <CopyText textToCopy={contractId}>
+                <TextLink>Copy</TextLink>
+              </CopyText>
+            </div>
+          </div>
+          {/* TODO(jiahuihu): Replace key id with something more meaningful  */}
+          <div className="AccountInfoRow">
+            <div className="AccountInfoCell AccountLabel">Key ID</div>
+            <div className="AccountInfoCell">
+              {shortenStellarKey(contractAccount.keyId)}
+            </div>
+            <div className="AccountInfoCell CopyButton">
+              <CopyText textToCopy={contractAccount.keyId}>
+                <TextLink>Copy</TextLink>
+              </CopyText>
+            </div>
+          </div>
+        </div>
+
+        {/* Contract actions */}
+        <div className="AccountInfo">
+          <div className="AccountInfoRow">
+            <div className="AccountInfoCell">
+              <TextLink
+                onClick={() =>
+                  setIsContractDetailsVisible(!isContractDetailsVisible)
+                }
+              >{`${
+                isContractDetailsVisible ? "Hide" : "Show"
+              } contract details`}</TextLink>
+            </div>
+          </div>
+
+          <div className="AccountInfoRow">
+            <div className="AccountInfoCell">
+              <div className="InfoButtonWrapper">
+                <TextLink
+                  onClick={handleRefreshAccount}
+                  disabled={contractAccount.status === ActionStatus.PENDING}>
+                  Refresh account
+                </TextLink>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Contract details */}
+      {isContractDetailsVisible && contractAccount.data && (
+        <div className="AccountDetails Section">
+          <Heading2>Contract details</Heading2>
+          <div className="AccountDetailsContent">
+            <Json src={contractAccount.data} />
+          </div>
+        </div>
+      )}
+    </Layout.Inset>
+  );
+};

--- a/packages/demo-wallet-client/src/components/CreatePasskeyModal.tsx
+++ b/packages/demo-wallet-client/src/components/CreatePasskeyModal.tsx
@@ -18,14 +18,19 @@ export const CreatePasskeyModal = ({ visible, onClose }: CreatePasskeyModalProps
   const handleSubmit = async () => {
     if (passkeyName.trim()) {
       dispatch(createPasskeyContract(passkeyName.trim()));
-      onClose();
+      handleClose()
     }
+  };
+
+  const handleClose = () => {
+    setPasskeyName(""); // Clear the input when modal is closed
+    onClose();
   };
 
   return (
     <Modal
       visible={visible}
-      onClose={onClose}
+      onClose={handleClose}
       parentId={CSS_MODAL_PARENT_ID}
     >
       <Modal.Heading>Create Passkey</Modal.Heading>
@@ -35,7 +40,7 @@ export const CreatePasskeyModal = ({ visible, onClose }: CreatePasskeyModalProps
           label="Your passkey name"
           value={passkeyName}
           onChange={(e: ChangeEvent<HTMLInputElement>) => setPasskeyName(e.target.value)}
-          placeholder="e.g., Alice’s Contract Key"
+          placeholder="e.g., Alice's Contract Key"
         />
       </Modal.Body>
       <Modal.Footer>

--- a/packages/demo-wallet-client/src/components/CreatePasskeyModal.tsx
+++ b/packages/demo-wallet-client/src/components/CreatePasskeyModal.tsx
@@ -30,9 +30,9 @@ export const CreatePasskeyModal = ({ visible, onClose }: CreatePasskeyModalProps
     >
       <Modal.Heading>Create Passkey</Modal.Heading>
       <Modal.Body>
-        <p>Enter a name for your passkey:</p>
         <Input
           id="passkey-name"
+          label="Your passkey name"
           value={passkeyName}
           onChange={(e: ChangeEvent<HTMLInputElement>) => setPasskeyName(e.target.value)}
           placeholder="e.g., Alice’s Contract Key"
@@ -40,7 +40,6 @@ export const CreatePasskeyModal = ({ visible, onClose }: CreatePasskeyModalProps
       </Modal.Body>
       <Modal.Footer>
         <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
-          <Button onClick={onClose}>Cancel</Button>
           <Button onClick={handleSubmit} disabled={!passkeyName.trim()}>
             Create
           </Button>

--- a/packages/demo-wallet-client/src/components/Header.tsx
+++ b/packages/demo-wallet-client/src/components/Header.tsx
@@ -7,7 +7,7 @@ import { useRedux } from "hooks/useRedux";
 export const Header = () => {
   const [modalVisible, setModalVisible] = useState(false);
 
-  const { account } = useRedux("account");
+  const { account, contractAccount } = useRedux("account", "contractAccount");
 
   const handleCloseModal = () => {
     setModalVisible(false);
@@ -17,7 +17,7 @@ export const Header = () => {
     <>
       <Layout.Header
         projectTitle="Demo Wallet"
-        {...(account.isAuthenticated
+        {...(account.isAuthenticated || contractAccount.isAuthenticated
           ? { onSignOut: () => setModalVisible(true) }
           : {})}
         hasDarkModeToggle

--- a/packages/demo-wallet-client/src/components/Logs.tsx
+++ b/packages/demo-wallet-client/src/components/Logs.tsx
@@ -10,7 +10,7 @@ import { AppDispatch } from "config/store";
 import { LogItemProps } from "types/types";
 
 export const Logs = () => {
-  const { account, logs } = useRedux("account", "logs");
+  const { logs } = useRedux("logs");
   const dispatch: AppDispatch = useDispatch();
 
   useEffect(() => {
@@ -80,7 +80,7 @@ export const Logs = () => {
     document.body.removeChild(element);
   };
 
-  if (!account.isAuthenticated) {
+  if (!logs.items.length) {
     return (
       <div className="SplitContainer Logs">
         <div className="Logs__content">
@@ -98,20 +98,16 @@ export const Logs = () => {
         <div className="Logs__content">
           <Layout.Inset>
             <div className="Logs__wrapper">
-              {logs.items.length ? (
-                logs.items.map((log: LogItemProps, index: number) => (
-                  <LogItem
-                    // eslint-disable-next-line react/no-array-index-key
-                    key={`${log.timestamp}-${index}`}
-                    variant={log.type}
-                    title={log.title}
-                    body={log.body}
-                    link={log.link}
-                  />
-                ))
-              ) : (
-                <p>No logs to show</p>
-              )}
+              {logs.items.map((log: LogItemProps, index: number) => (
+                <LogItem
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={`${log.timestamp}-${index}`}
+                  variant={log.type}
+                  title={log.title}
+                  body={log.body}
+                  link={log.link}
+                />
+              ))}
             </div>
           </Layout.Inset>
         </div>

--- a/packages/demo-wallet-client/src/components/PrivateRoute.tsx
+++ b/packages/demo-wallet-client/src/components/PrivateRoute.tsx
@@ -1,17 +1,21 @@
 import { Navigate, useLocation } from "react-router-dom";
 import { useRedux } from "hooks/useRedux";
+import React from "react";
 
 export const PrivateRoute = ({
   children,
 }: {
   children: React.ReactElement;
 }) => {
-  const { account } = useRedux("account");
+  const { account, contractAccount } = useRedux("account", "contractAccount");
   const location = useLocation();
 
-  return account.isAuthenticated ? (
-    children
-  ) : (
+  if (account.isAuthenticated || contractAccount.isAuthenticated) {
+    return children;
+  }
+
+  // If we're not authenticated, redirect to home
+  return (
     <Navigate
       to={{
         pathname: "/",

--- a/packages/demo-wallet-client/src/components/SettingsHandler.tsx
+++ b/packages/demo-wallet-client/src/components/SettingsHandler.tsx
@@ -10,14 +10,14 @@ import { log } from "demo-wallet-shared/build/helpers/log";
 import { useRedux } from "hooks/useRedux";
 import { AppDispatch } from "config/store";
 import { ActionStatus, SearchParams } from "types/types";
+import { fetchContractAccountAction } from "../ducks/contractAccount";
 
 export const SettingsHandler = ({
   children,
 }: {
   children: React.ReactNode;
 }) => {
-  const { account } = useRedux("account");
-
+  const { account, contractAccount } = useRedux("account", "contractAccount");
   const dispatch: AppDispatch = useDispatch();
   const navigate = useNavigate();
   const location = useLocation();
@@ -29,6 +29,7 @@ export const SettingsHandler = ({
   const claimableBalanceSupportedParam = queryParams.get(
     SearchParams.CLAIMABLE_BALANCE_SUPPORTED,
   );
+  const contractIdParam = queryParams.get(SearchParams.CONTRACT_ID);
 
   // Asset overrides
   useEffect(() => {
@@ -109,6 +110,13 @@ export const SettingsHandler = ({
       });
     }
   }, [account.status, location.search, account.isAuthenticated, navigate]);
+
+  // Handle contract ID from URL
+  useEffect(() => {
+    if (contractIdParam && contractIdParam !== contractAccount.data?.contract) {
+      dispatch(fetchContractAccountAction(contractIdParam));
+    }
+  }, [contractIdParam, dispatch, contractAccount.data?.contract]);
 
   return <>{children}</>;
 };

--- a/packages/demo-wallet-client/src/components/SettingsHandler.tsx
+++ b/packages/demo-wallet-client/src/components/SettingsHandler.tsx
@@ -103,20 +103,28 @@ export const SettingsHandler = ({
 
   // Go to /account page if fetching account was success
   useEffect(() => {
-    if (account.status === ActionStatus.SUCCESS && account.isAuthenticated) {
+    if ((account.status === ActionStatus.SUCCESS && account.isAuthenticated) ||
+      (contractAccount.status === ActionStatus.SUCCESS && contractAccount.isAuthenticated)) {
       navigate({
         pathname: "/account",
         search: location.search,
       });
     }
-  }, [account.status, location.search, account.isAuthenticated, navigate]);
+  }, [account.status, location.search, account.isAuthenticated, navigate, contractAccount.status, contractAccount.isAuthenticated]);
 
   // Handle contract ID from URL
   useEffect(() => {
-    if (contractIdParam && contractIdParam !== contractAccount.data?.contract) {
-      dispatch(fetchContractAccountAction(contractIdParam));
+    if (contractIdParam) {
+      try {
+        dispatch(fetchContractAccountAction(contractIdParam));
+      } catch (error) {
+        log.error({
+          title: "Fetch contract account error",
+          body: getErrorMessage(error),
+        });
+      }
     }
-  }, [contractIdParam, dispatch, contractAccount.data?.contract]);
+  }, [contractIdParam, dispatch]);
 
   return <>{children}</>;
 };

--- a/packages/demo-wallet-client/src/components/SignOutModal.tsx
+++ b/packages/demo-wallet-client/src/components/SignOutModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import {
   Button,
   TextLink,
@@ -12,9 +12,11 @@ import {
 import { resetStoreAction } from "config/store";
 import { getCurrentSessionParams } from "demo-wallet-shared/build/helpers/getCurrentSessionParams";
 import { SearchParams, StringObject } from "types/types";
+import { contractAccountSelector } from "../ducks/contractAccount";
 
 export const SignOutModal = ({ onClose }: { onClose: () => void }) => {
   const [sessionParams, setSessionParams] = useState<SearchParams[]>([]);
+  const { isAuthenticated } = useSelector(contractAccountSelector);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -41,32 +43,40 @@ export const SignOutModal = ({ onClose }: { onClose: () => void }) => {
     return sessionParams.map((s) => paramText[s]).join(", ");
   };
 
+  const accountSignOutBody =
+    <Modal.Body>
+      <p>
+        You can reload the account using your secret key or press back in your
+        browser to sign back in.
+      </p>
+
+      {sessionParams.length > 0 && (
+        <InfoBlock variant={InfoBlock.variant.warning}>
+          <p>
+            {`You have session data (${getMessageText()}) that will be lost when you sign out. You can copy the URL to save it.`}
+          </p>
+          <div className="SessionParamsWrapper">
+            <CopyText
+              textToCopy={window.location.toString()}
+              tooltipPosition={CopyText.tooltipPosition.RIGHT}
+              showTooltip
+            >
+              <TextLink iconLeft={<Icon.Copy />}>Copy URL</TextLink>
+            </CopyText>
+          </div>
+        </InfoBlock>
+      )}
+    </Modal.Body>
+
+  const contractAccountSignOutBody =
+    <Modal.Body>
+      <p>Thanks for using the Demo Wallet contract account.</p>
+      <p>Come back anytime by reconnecting with the same passkey.</p>
+    </Modal.Body>
+
   return (
     <>
-      <Modal.Body>
-        <p>
-          You can reload the account using your secret key or press back in your
-          browser to sign back in.
-        </p>
-
-        {sessionParams.length > 0 && (
-          <InfoBlock variant={InfoBlock.variant.warning}>
-            <p>
-              {`You have session data (${getMessageText()}) that will be lost when you sign out. You can copy the URL to save it.`}
-            </p>
-            <div className="SessionParamsWrapper">
-              <CopyText
-                textToCopy={window.location.toString()}
-                tooltipPosition={CopyText.tooltipPosition.RIGHT}
-                showTooltip
-              >
-                <TextLink iconLeft={<Icon.Copy />}>Copy URL</TextLink>
-              </CopyText>
-            </div>
-          </InfoBlock>
-        )}
-      </Modal.Body>
-
+      { isAuthenticated ? contractAccountSignOutBody : accountSignOutBody }
       <Modal.Footer>
         <Button onClick={handleSignOut}>Sign out</Button>
         <Button variant={Button.variant.secondary} onClick={onClose}>

--- a/packages/demo-wallet-client/src/components/SignOutModal.tsx
+++ b/packages/demo-wallet-client/src/components/SignOutModal.tsx
@@ -16,7 +16,7 @@ import { contractAccountSelector } from "../ducks/contractAccount";
 
 export const SignOutModal = ({ onClose }: { onClose: () => void }) => {
   const [sessionParams, setSessionParams] = useState<SearchParams[]>([]);
-  const { isAuthenticated } = useSelector(contractAccountSelector);
+  const { isAuthenticated: isContractAuthenticated } = useSelector(contractAccountSelector);
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -71,12 +71,12 @@ export const SignOutModal = ({ onClose }: { onClose: () => void }) => {
   const contractAccountSignOutBody =
     <Modal.Body>
       <p>Thanks for using the Demo Wallet contract account.</p>
-      <p>Come back anytime by reconnecting with the same passkey.</p>
+      <p>You can use the same passkey to sign back in.</p>
     </Modal.Body>
 
   return (
     <>
-      { isAuthenticated ? contractAccountSignOutBody : accountSignOutBody }
+      { isContractAuthenticated ? contractAccountSignOutBody : accountSignOutBody }
       <Modal.Footer>
         <Button onClick={handleSignOut}>Sign out</Button>
         <Button variant={Button.variant.secondary} onClick={onClose}>

--- a/packages/demo-wallet-client/src/config/constants.ts
+++ b/packages/demo-wallet-client/src/config/constants.ts
@@ -5,3 +5,5 @@ export const SOROBAN_CONFIG = {
 } as const;
 
 export const SOURCE_KEYPAIR_SECRET = "SDIHUAHOUBN5G4GBM276BVG7JYVFTCJYRCDK2ZI37IJ5KRX7LFRRIQNV"
+
+export const STELLAR_EXPERT_API = "https://api.stellar.expert/explorer/testnet";

--- a/packages/demo-wallet-client/src/config/store.ts
+++ b/packages/demo-wallet-client/src/config/store.ts
@@ -27,6 +27,7 @@ import { reducer as trustAsset } from "ducks/trustAsset";
 import { reducer as untrustedAssets } from "ducks/untrustedAssets";
 import { reducer as custodial } from "ducks/custodial";
 import { reducer as extra } from "ducks/extra";
+import { reducer as contractAccount } from "../ducks/contractAccount";
 
 const RESET_STORE_ACTION_TYPE = "RESET";
 export type RootState = ReturnType<typeof store.getState>;
@@ -62,6 +63,9 @@ const reducers = combineReducers({
   settings,
   trustAsset,
   untrustedAssets,
+
+  // Contract Account Reducer
+  contractAccount,
 });
 
 export const resetStoreAction = createAction(RESET_STORE_ACTION_TYPE);

--- a/packages/demo-wallet-client/src/ducks/contractAccount.ts
+++ b/packages/demo-wallet-client/src/ducks/contractAccount.ts
@@ -1,12 +1,31 @@
-import { createAsyncThunk } from "@reduxjs/toolkit";
-import { RejectMessage } from "../types/types";
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import {
+  ContractAccountDetails,
+  ContractAccountState,
+  RejectMessage,
+} from "../types/types";
 import { RootState } from "../config/store";
 import { log } from "demo-wallet-shared/build/helpers/log";
 import { getErrorMessage } from "demo-wallet-shared/build/helpers/getErrorMessage";
 import { SmartWalletService } from "../services/SmartWalletService";
+import { ActionStatus } from "../types/types";
+import {
+  getErrorString
+} from "demo-wallet-shared/build/helpers/getErrorString";
+import {
+  fetchContractAccountDetails
+} from "../helpers/fetchContractAccountDetails";
+
+const initialState: ContractAccountState = {
+  status: undefined,
+  data: null,
+  keyId: "",
+  isAuthenticated: false,
+  error: null,
+};
 
 export const createPasskeyContract = createAsyncThunk<
-  { contractId: string; keyId: string; },
+  { data: ContractAccountDetails; keyId: string; },
   string,
   { rejectValue: RejectMessage; state: RootState }
 >("contractAccount/createPasskeyContract", async (passkeyName, { rejectWithValue }) => {
@@ -14,13 +33,15 @@ export const createPasskeyContract = createAsyncThunk<
     log.instruction({ title: "Deploying new contract" });
     const swService = SmartWalletService.getInstance();
     const result = await swService.createPasskeyContract(passkeyName);
+
+    const info = await fetchContractAccountDetails(result.contractId)
     return {
-      contractId: result.contractId,
+      data : info,
       keyId: result.pkId,
     };
   } catch (error) {
     log.error({
-      title: "Deploying new contract failed",
+      title: "Deploying contract failed",
       body: getErrorMessage(error),
     });
     return rejectWithValue({
@@ -31,7 +52,7 @@ export const createPasskeyContract = createAsyncThunk<
 });
 
 export const connectPasskeyContract = createAsyncThunk<
-  { contractId: string; keyId: string; },
+  { data: ContractAccountDetails; keyId: string; },
   void,
   { rejectValue: RejectMessage; state: RootState }
 >(
@@ -41,8 +62,9 @@ export const connectPasskeyContract = createAsyncThunk<
       log.instruction({ title: "Connecting contract" });
       const swService = SmartWalletService.getInstance();
       const result = await swService.connectPasskeyContract();
+      const info = await fetchContractAccountDetails(result.contractId)
       return {
-        contractId: result.contractId,
+        data : info,
         keyId: result.pkId,
       };
     } catch (error) {
@@ -57,3 +79,103 @@ export const connectPasskeyContract = createAsyncThunk<
     }
   }
 );
+
+export const fetchContractAccountAction = createAsyncThunk<
+  { data: ContractAccountDetails },
+  string,
+  { rejectValue: RejectMessage; state: RootState }
+>(
+  "contractAccount/fetchContractAccountAction",
+  async ( contractId, { rejectWithValue }) => {
+    log.request({
+      title: `Fetching contract info`,
+      body: `Contract ID: ${contractId}`,
+    });
+
+    let contractAccount: ContractAccountDetails | null = null;
+    try {
+      contractAccount = await fetchContractAccountDetails(contractId);
+      log.response({
+        title: `Contract info fetched`,
+        body: contractAccount,
+      });
+    } catch (error) {
+      log.error({
+        title: `Fetching contract failed`,
+        body: getErrorString(error),
+      });
+      return rejectWithValue({
+        errorString: getErrorString(error),
+      });
+    }
+    return { data: contractAccount };
+  },
+);
+
+const contractAccountSlice = createSlice({
+  name: "contractAccount",
+  initialState,
+  reducers: {
+    resetContractAccount: () => initialState,
+    resetContractAccountStatus: (state) => {
+      state.status = undefined;
+    },
+    updateContractAccount: (
+      state,
+      action: PayloadAction<Partial<ContractAccountState>>
+    ) => ({
+      ...state,
+      ...action.payload,
+    }),
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(createPasskeyContract.pending, (state) => {
+        state.status = ActionStatus.PENDING;
+        state.error = null;
+      })
+      .addCase(createPasskeyContract.fulfilled, (state, action) => {
+        state.status = ActionStatus.SUCCESS;
+        state.data = action.payload.data;
+        state.keyId = action.payload.keyId;
+        state.isAuthenticated = true;
+      })
+      .addCase(createPasskeyContract.rejected, (state, action) => {
+        state.status = ActionStatus.ERROR;
+        state.error = action.payload?.errorString || "Unknown error occurred";
+      })
+      .addCase(connectPasskeyContract.pending, (state) => {
+        state.status = ActionStatus.PENDING;
+        state.error = null;
+      })
+      .addCase(connectPasskeyContract.fulfilled, (state, action) => {
+        state.status = ActionStatus.SUCCESS;
+        state.data = action.payload.data;
+        state.keyId = action.payload.keyId;
+        state.isAuthenticated = true;
+      })
+      .addCase(connectPasskeyContract.rejected, (state, action) => {
+        state.status = ActionStatus.ERROR;
+        state.error = action.payload?.errorString || "Unknown error occurred";
+      })
+      .addCase(fetchContractAccountAction.pending, (state = initialState) => {
+        state.status = ActionStatus.PENDING;
+      })
+      .addCase(fetchContractAccountAction.fulfilled, (state, action) => {
+        state.status = ActionStatus.SUCCESS;
+        state.data = action.payload.data;
+        state.isAuthenticated = true;
+      })
+      .addCase(fetchContractAccountAction.rejected, (state, action) => {
+        state.status = ActionStatus.ERROR;
+        state.error = action.payload?.errorString || "Unknown error occurred";
+      });
+  },
+});
+
+export const { resetContractAccount, resetContractAccountStatus, updateContractAccount } =
+  contractAccountSlice.actions;
+
+export const contractAccountSelector = (state: RootState) => state.contractAccount;
+
+export const { reducer } = contractAccountSlice;

--- a/packages/demo-wallet-client/src/ducks/contractAccount.ts
+++ b/packages/demo-wallet-client/src/ducks/contractAccount.ts
@@ -18,6 +18,7 @@ import {
 
 const initialState: ContractAccountState = {
   status: undefined,
+  contractId: "",
   data: null,
   keyId: "",
   isAuthenticated: false,
@@ -25,19 +26,17 @@ const initialState: ContractAccountState = {
 };
 
 export const createPasskeyContract = createAsyncThunk<
-  { data: ContractAccountDetails; keyId: string; },
+  { contractId: string; keyId: string; },
   string,
   { rejectValue: RejectMessage; state: RootState }
 >("contractAccount/createPasskeyContract", async (passkeyName, { rejectWithValue }) => {
   try {
     log.instruction({ title: "Deploying new contract" });
     const swService = SmartWalletService.getInstance();
-    const result = await swService.createPasskeyContract(passkeyName);
-
-    const info = await fetchContractAccountDetails(result.contractId)
+    const { contractId, pkId } = await swService.createPasskeyContract(passkeyName);
     return {
-      data : info,
-      keyId: result.pkId,
+      contractId,
+      keyId: pkId,
     };
   } catch (error) {
     log.error({
@@ -52,7 +51,7 @@ export const createPasskeyContract = createAsyncThunk<
 });
 
 export const connectPasskeyContract = createAsyncThunk<
-  { data: ContractAccountDetails; keyId: string; },
+  { contractId: string; keyId: string; },
   void,
   { rejectValue: RejectMessage; state: RootState }
 >(
@@ -61,11 +60,10 @@ export const connectPasskeyContract = createAsyncThunk<
     try {
       log.instruction({ title: "Connecting contract" });
       const swService = SmartWalletService.getInstance();
-      const result = await swService.connectPasskeyContract();
-      const info = await fetchContractAccountDetails(result.contractId)
+      const { contractId, pkId } = await swService.connectPasskeyContract();
       return {
-        data : info,
-        keyId: result.pkId,
+        contractId,
+        keyId: pkId,
       };
     } catch (error) {
       log.error({
@@ -136,9 +134,8 @@ const contractAccountSlice = createSlice({
       })
       .addCase(createPasskeyContract.fulfilled, (state, action) => {
         state.status = ActionStatus.SUCCESS;
-        state.data = action.payload.data;
+        state.contractId = action.payload.contractId;
         state.keyId = action.payload.keyId;
-        state.isAuthenticated = true;
       })
       .addCase(createPasskeyContract.rejected, (state, action) => {
         state.status = ActionStatus.ERROR;
@@ -150,9 +147,8 @@ const contractAccountSlice = createSlice({
       })
       .addCase(connectPasskeyContract.fulfilled, (state, action) => {
         state.status = ActionStatus.SUCCESS;
-        state.data = action.payload.data;
+        state.contractId = action.payload.contractId
         state.keyId = action.payload.keyId;
-        state.isAuthenticated = true;
       })
       .addCase(connectPasskeyContract.rejected, (state, action) => {
         state.status = ActionStatus.ERROR;

--- a/packages/demo-wallet-client/src/helpers/fetchContractAccountDetails.ts
+++ b/packages/demo-wallet-client/src/helpers/fetchContractAccountDetails.ts
@@ -1,0 +1,19 @@
+import { STELLAR_EXPERT_API } from "../config/constants";
+import { ContractAccountDetails } from "../types/types";
+
+export const fetchContractAccountDetails = async (
+  contractId: string,
+): Promise<ContractAccountDetails> => {
+  try {
+    const response = await fetch(
+      `${STELLAR_EXPERT_API}/contract/${contractId}`,
+    );
+    const responseJson = await response.json();
+    if (responseJson.error) {
+      throw responseJson.error;
+    }
+    return responseJson;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/packages/demo-wallet-client/src/pages/Account.tsx
+++ b/packages/demo-wallet-client/src/pages/Account.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import {  useState } from "react";
 import { useDispatch } from "react-redux";
 import { Modal } from "@stellar/design-system";
 import { AccountInfo } from "components/AccountInfo";
@@ -12,9 +12,10 @@ import { CSS_MODAL_PARENT_ID } from "demo-wallet-shared/build/constants/settings
 import { resetActiveAssetAction } from "ducks/activeAsset";
 import { useRedux } from "hooks/useRedux";
 import { Asset } from "types/types";
+import { ContractAccountInfo } from "../components/ContractAccountInfo";
 
 export const Account = () => {
-  const { account } = useRedux("account");
+  const { account, contractAccount} = useRedux("account", "contractAccount");
   const [sendPaymentModalVisible, setSendPaymentModalVisible] = useState(false);
   const [currentAsset, setCurrentAsset] = useState<Asset | undefined>();
 
@@ -30,7 +31,7 @@ export const Account = () => {
     setSendPaymentModalVisible(true);
   };
 
-  if (!account.data?.id) {
+  if (!account.data?.id && !contractAccount.data?.contract) {
     return null;
   }
 
@@ -38,6 +39,9 @@ export const Account = () => {
     <>
       {/* Account */}
       <AccountInfo />
+
+      {/* Contract Account Info */}
+      <ContractAccountInfo />
 
       {/* Assets / Balances */}
       <Assets onSendPayment={handleSendPayment} />

--- a/packages/demo-wallet-client/src/pages/Account.tsx
+++ b/packages/demo-wallet-client/src/pages/Account.tsx
@@ -1,4 +1,4 @@
-import {  useState } from "react";
+import { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Modal } from "@stellar/design-system";
 import { AccountInfo } from "components/AccountInfo";

--- a/packages/demo-wallet-client/src/pages/Landing.tsx
+++ b/packages/demo-wallet-client/src/pages/Landing.tsx
@@ -22,7 +22,7 @@ import { ActionStatus, SearchParams } from "types/types";
 import { connectPasskeyContract } from "../ducks/contractAccount";
 
 export const Landing = () => {
-  const { account } = useRedux("account");
+  const { account, contractAccount } = useRedux("account", "contractAccount");
   const [isConnectAccountModalVisible, setIsConnectAccountModalVisible] =
     useState(false);
   const [isCreatePasskeyModalVisible, setIsCreatePasskeyModalVisible] =
@@ -40,6 +40,12 @@ export const Landing = () => {
       navigate(searchParam.update(SearchParams.SECRET_KEY, account.secretKey));
     }
   }, [account.secretKey, account.status, account.isAuthenticated, navigate]);
+
+  useEffect(() => {
+    if (contractAccount.status === ActionStatus.SUCCESS && contractAccount.isAuthenticated) {
+      navigate(`/account?contractId=${contractAccount.data?.contract}`);
+    }
+  }, [contractAccount.data?.contract, contractAccount.isAuthenticated, contractAccount.status, navigate]);
 
   const handleCreateAccount = () => {
     dispatch(createRandomAccount());

--- a/packages/demo-wallet-client/src/pages/Landing.tsx
+++ b/packages/demo-wallet-client/src/pages/Landing.tsx
@@ -42,10 +42,10 @@ export const Landing = () => {
   }, [account.secretKey, account.status, account.isAuthenticated, navigate]);
 
   useEffect(() => {
-    if (contractAccount.status === ActionStatus.SUCCESS && contractAccount.isAuthenticated) {
-      navigate(`/account?contractId=${contractAccount.data?.contract}`);
+    if (contractAccount.status === ActionStatus.SUCCESS && !contractAccount.isAuthenticated) {
+      navigate(searchParam.update(SearchParams.CONTRACT_ID, contractAccount.contractId));
     }
-  }, [contractAccount.data?.contract, contractAccount.isAuthenticated, contractAccount.status, navigate]);
+  }, [contractAccount, contractAccount.contractId, contractAccount.isAuthenticated, contractAccount.status, navigate]);
 
   const handleCreateAccount = () => {
     dispatch(createRandomAccount());
@@ -56,29 +56,31 @@ export const Landing = () => {
   return (
     <Layout.Inset>
       <div className="Landing__container">
-        <Heading3>Import or generate keypair</Heading3>
+        <div className="Landing__section">
+          <Heading3>Import or generate keypair</Heading3>
 
-        <div className="Landing__buttons">
-          <TextLink
-            onClick={() => setIsConnectAccountModalVisible(true)}
-            variant={TextLink.variant.secondary}
-            disabled={isPending}
-            underline
-          >
-            Provide a secret key (testnet only)
-          </TextLink>
-
-          <div className="Layout__inline">
+          <div className="Landing__buttons">
             <TextLink
-              onClick={handleCreateAccount}
+              onClick={() => setIsConnectAccountModalVisible(true)}
               variant={TextLink.variant.secondary}
               disabled={isPending}
               underline
             >
-              Generate keypair for new account (testnet only)
+              Provide a secret key (testnet only)
             </TextLink>
 
-            {!isConnectAccountModalVisible && isPending && <Loader />}
+            <div className="Layout__inline">
+              <TextLink
+                onClick={handleCreateAccount}
+                variant={TextLink.variant.secondary}
+                disabled={isPending}
+                underline
+              >
+                Generate keypair for new account (testnet only)
+              </TextLink>
+
+              {!isConnectAccountModalVisible && isPending && <Loader />}
+            </div>
           </div>
         </div>
 
@@ -90,27 +92,29 @@ export const Landing = () => {
           <ConnectAccount />
         </Modal>
 
-        <Heading3>Connect or create contract account</Heading3>
+        <div className="Landing__section">
+          <Heading3>Connect or create contract account</Heading3>
 
-        <div className="Landing__buttons">
-          <TextLink
-            onClick={() => dispatch(connectPasskeyContract())}
-            variant={TextLink.variant.secondary}
-            disabled={isPending}
-            underline
-          >
-            Connect existing contract account (testnet only)
-          </TextLink>
-
-          <div className="Layout__inline">
+          <div className="Landing__buttons">
             <TextLink
-              onClick={() => setIsCreatePasskeyModalVisible(true)}
+              onClick={() => dispatch(connectPasskeyContract())}
               variant={TextLink.variant.secondary}
               disabled={isPending}
               underline
             >
-              Create new contract account using Passkey (testnet only)
+              Connect existing contract account (testnet only)
             </TextLink>
+
+            <div className="Layout__inline">
+              <TextLink
+                onClick={() => setIsCreatePasskeyModalVisible(true)}
+                variant={TextLink.variant.secondary}
+                disabled={isPending}
+                underline
+              >
+                Create new contract account using Passkey (testnet only)
+              </TextLink>
+            </div>
           </div>
         </div>
 

--- a/packages/demo-wallet-client/src/types/types.ts
+++ b/packages/demo-wallet-client/src/types/types.ts
@@ -27,6 +27,7 @@ export enum SearchParams {
   UNTRUSTED_ASSETS = "untrustedAssets",
   ASSET_OVERRIDES = "assetOverrides",
   CLAIMABLE_BALANCE_SUPPORTED = "claimableBalanceSupported",
+  CONTRACT_ID = "contractId",
 }
 
 export enum AssetCategory {
@@ -403,6 +404,7 @@ export interface LogItemProps {
 
 export interface Store {
   account: AccountInitialState;
+  contractAccount: ContractAccountState;
   activeAsset: ActiveAssetInitialState;
   allAssets: AllAssetsInitialState;
   assetOverrides: AssetOverridesInitialState;
@@ -783,3 +785,40 @@ export type FetchAccountError =
   | BadRequestError
   | NetworkError
   | (NotFoundError & NotFundedError);
+
+export interface ContractAccountState {
+  status: ActionStatus | undefined;
+  data: ContractAccountDetails | null;
+  keyId: string;
+  isAuthenticated: boolean;
+  error: string | null;
+}
+
+export interface ContractAccountDetails {
+  contract: string;
+  account?: string;
+  created: number;
+  creator: string;
+  payments?: number;
+  trades?: number;
+  wasm?: string;
+  storage_entries?: number;
+  validation?: {
+    status?: "verified" | "unverified";
+    repository?: string;
+    commit?: string;
+    package?: string;
+    make?: string;
+    ts?: number;
+  };
+  versions?: number;
+  salt?: string;
+  asset?: string;
+  code?: string;
+  issuer?: string;
+  functions?: {
+    invocations: number;
+    subinvocations: number;
+    function: string;
+  }[];
+}

--- a/packages/demo-wallet-client/src/types/types.ts
+++ b/packages/demo-wallet-client/src/types/types.ts
@@ -788,6 +788,7 @@ export type FetchAccountError =
 
 export interface ContractAccountState {
   status: ActionStatus | undefined;
+  contractId: string;
   data: ContractAccountDetails | null;
   keyId: string;
   isAuthenticated: boolean;

--- a/packages/demo-wallet-shared/helpers/searchParam.ts
+++ b/packages/demo-wallet-shared/helpers/searchParam.ts
@@ -32,7 +32,6 @@ const update = (
       );
       break;
     case SearchParams.CONTRACT_ID:
-      console.log("searchParaM: " + currentParamValue)
       queryParams.set(SearchParams.CONTRACT_ID, value);
       break;
     default:

--- a/packages/demo-wallet-shared/helpers/searchParam.ts
+++ b/packages/demo-wallet-shared/helpers/searchParam.ts
@@ -31,6 +31,10 @@ const update = (
         updateValue({ currentVal: currentParamValue, newVal: value }),
       );
       break;
+    case SearchParams.CONTRACT_ID:
+      console.log("searchParaM: " + currentParamValue)
+      queryParams.set(SearchParams.CONTRACT_ID, value);
+      break;
     default:
       throw new Error(`Search param \`${searchParam}\` does not exist`);
   }

--- a/packages/demo-wallet-shared/helpers/searchParam.ts
+++ b/packages/demo-wallet-shared/helpers/searchParam.ts
@@ -23,6 +23,8 @@ const update = (
       }
       break;
     case SearchParams.SECRET_KEY:
+      // Only remove contract ID when setting secret key
+      queryParams.delete(SearchParams.CONTRACT_ID);
       queryParams.set(SearchParams.SECRET_KEY, value);
       break;
     case SearchParams.UNTRUSTED_ASSETS:
@@ -32,6 +34,11 @@ const update = (
       );
       break;
     case SearchParams.CONTRACT_ID:
+      // Clear all auth-related params when setting contract ID
+      queryParams.delete(SearchParams.SECRET_KEY);
+      queryParams.delete(SearchParams.CLAIMABLE_BALANCE_SUPPORTED);
+      queryParams.delete(SearchParams.UNTRUSTED_ASSETS);
+      // Set the new contract ID
       queryParams.set(SearchParams.CONTRACT_ID, value);
       break;
     default:

--- a/packages/demo-wallet-shared/types/types.ts
+++ b/packages/demo-wallet-shared/types/types.ts
@@ -23,6 +23,7 @@ export enum SearchParams {
   UNTRUSTED_ASSETS = "untrustedAssets",
   ASSET_OVERRIDES = "assetOverrides",
   CLAIMABLE_BALANCE_SUPPORTED = "claimableBalanceSupported",
+  CONTRACT_ID = "contractId",
 }
 
 export enum AssetCategory {


### PR DESCRIPTION
### What's changed
This PR implements the UI for contract account info display and redirection, other functionalities including refresh, sign out etc.

======== Update 05/15 =======
1. Fix incorrect preservation of contractId in the URL when redirecting between an invalid contract account and a g-account, and vice versa (see searchParams.ts).
2. Fix issue where error logs for invalid account or contract account were hidden, queued, and then flushed out on the next successful action (see Logs.tsx).
3. UI improvements including spacing, modal etc



### Limitations
This PR can not be tested directly in browser previews due to `api.stellar.expert` CORS restrictions. Please reference the solution [here](https://stellarfoundation.slack.com/archives/C06KTGUULUF/p1747063641096309)

### Test
1. Install the extension in **LIMITATION** section (REMEMBER TO TURN IT OFF AFTER USE)
2. Create or connect your passkey, it will redirect you to the account page
3. Open console, check log info, try refresh and sign out function etc
![Screenshot 2025-05-12 at 1 23 56 PM](https://github.com/user-attachments/assets/631ff22d-2491-4978-97a2-e26f9e909847)


