### PR TITLE
Force form data version resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "demo-wallet-shared": "^2.0.0",
     "form-data": "^4.0.4",
     "npm-run-all": "^4.1.5"
+  },
+  "resolutions": {
+    "form-data": "4.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4982,16 +4982,7 @@ fork-ts-checker-webpack-plugin@^8.0.0:
     semver "^7.3.5"
     tapable "^2.2.1"
 
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@^4.0.4:
+form-data@4.0.4, form-data@^4.0.0, form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==


### PR DESCRIPTION
`@stellar/stellar-sdk` has a direct dependency on an older version of `axios` that still uses the vulnerable `form-data@4.0.0`, adding `resolutions` to force it resolves to 4.0.4