### PR TITLE
Fix `/sign-tx` source account authorization bypass            

### DIFF
--- a/packages/demo-wallet-server/src/index.ts
+++ b/packages/demo-wallet-server/src/index.ts
@@ -138,19 +138,20 @@ app.post("/sign-tx", async (req, res) => {
 
     // verify that the transaction does not operate on the source account
     const simulatedTx = await rpcClient.simulateTransaction(tx);
-    if (Api.isSimulationSuccess(simulatedTx)) {
-      simulatedTx.result?.auth?.forEach((entry) => {
-        if (
-          entry.credentials().switch() !=
-          xdr.SorobanCredentialsType.sorobanCredentialsSourceAccount() &&
-          Address.fromScAddress(
-            entry.credentials().address().address(),
-          ).toString() === sourceKeypair.publicKey()
-        ) {
-          throw new Error("Transaction cannot operate on the source account");
-        }
-      });
+    if (!Api.isSimulationSuccess(simulatedTx)) {
+      throw new Error("Transaction simulation failed");
     }
+    simulatedTx.result?.auth?.forEach((entry) => {
+      if (
+        entry.credentials().switch() ==
+        xdr.SorobanCredentialsType.sorobanCredentialsSourceAccount() ||
+        Address.fromScAddress(
+          entry.credentials().address().address(),
+        ).toString() === sourceKeypair.publicKey()
+      ) {
+        throw new Error("Transaction cannot operate on the source account");
+      }
+    });
 
     tx.sign(sourceKeypair);
     res.set("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
Fix`/sign-tx` validation tallowing transactions using `sorobanCredentialsSourceAccount` to bypass the source account protection check. 

 In Soroban, there are two ways a contract call can be authorized:                                                                                                                
  1. Source account credentials — the call is authorized by whoever signs the transaction                                                                                          
  2. Address credentials — the call is authorized by a specific account address                                                                                                    
                                                                                                                                                                                 
  The original check only caught case 2 (address matching the server's key) but skipped case 1 entirely due to a logic error (`!= && ...` short-circuits to false). This meant an attacker could craft a transaction that uses source account credentials to perform any contract call as the server — transferring tokens, calling admin functions, etc. — and the server would sign it without complaint.
                                                                                                                                                                                   
  Fix: Changed the condition to `== ||` so transactions are rejected if they use source account credentials or if they reference the server's address directly.                   